### PR TITLE
:bug: fix: run build before deploying to Cloudflare

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ jobs:
       
       - name: Setup
         uses: ./.github/actions/setup-project
+
+      - name: Run build
+        run: pnpm build
       
       # Wrangler automatically detects if it's a PR and creates a preview
       - name: Deploy to Cloudflare

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           command: >
             ${{ github.ref == 'refs/heads/main' 
               && 'deploy' 
-              || 'versions upload 
+              || 'versions upload' 
             }}
 
       - name: Update Deployment (Success)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           command: >
             ${{ github.ref == 'refs/heads/main' 
               && 'deploy' 
-              || 'versions upload --experimental-versions' 
+              || 'versions upload 
             }}
 
       - name: Update Deployment (Success)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,19 +7,45 @@ jobs:
     permissions:
       contents: read
       deployments: write
-      pull-requests: write # Required to post the preview URL comment
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      
+
+      - name: Create GitHub Deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        if: github.event_name == 'pull_request'
+        with:
+          token: ${{ github.token }}
+          environment: Preview (${{ github.head_ref }})
+          initial-status: pending
+
       - name: Setup
         uses: ./.github/actions/setup-project
 
       - name: Run build
         run: pnpm build
-      
-      # Wrangler automatically detects if it's a PR and creates a preview
+
       - name: Deploy to Cloudflare
+        id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Update Deployment (Success)
+        uses: chrnorm/deployment-status@v2
+        if: github.event_name == 'pull_request' && success()
+        with:
+          token: ${{ github.token }}
+          environment-url: ${{ steps.deploy.outputs.deployment-url }}
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update Deployment (Failure)
+        uses: chrnorm/deployment-status@v2
+        if: github.event_name == 'pull_request' && failure()
+        with:
+          token: ${{ github.token }}
+          state: 'error'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,14 +11,13 @@ jobs:
     permissions:
       contents: read
       deployments: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
       - name: Create GitHub Deployment
         uses: chrnorm/deployment-action@v2
         id: deployment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         with:
           token: ${{ github.token }}
           environment: Preview (${{ github.head_ref }})
@@ -32,6 +31,7 @@ jobs:
 
       - name: Deploy to Cloudflare (Preview)
         id: deploy
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Update Deployment (Success)
         uses: chrnorm/deployment-status@v2
-        if: github.event_name == 'pull_request' && success()
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && success()
         with:
           token: ${{ github.token }}
           environment-url: ${{ steps.deploy.outputs.deployment-url }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Update Deployment (Failure)
         uses: chrnorm/deployment-status@v2
-        if: github.event_name == 'pull_request' && failure()
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && failure()
         with:
           token: ${{ github.token }}
           state: 'error'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,12 +26,17 @@ jobs:
       - name: Run build
         run: pnpm build
 
-      - name: Deploy to Cloudflare
+      - name: Deploy to Cloudflare (Preview)
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >
+            ${{ github.ref == 'refs/heads/main' 
+              && 'deploy' 
+              || 'versions upload --experimental-versions' 
+            }}
 
       - name: Update Deployment (Success)
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Setup
         uses: ./.github/actions/setup-project
+
       - name: Run build
         run: pnpm build
+
       - name: Release (or dry-run on PR)
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,7 @@
   "name": "quiz-app",
   "main": "src/entry.ts",
   "compatibility_date": "2026-04-27",
+  "preview_urls": true,
   "assets": {
     "binding": "ASSETS",
     "directory": "./public"


### PR DESCRIPTION
Ensures that the build is performed before attempting the deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable preview URLs for worker deployments.
* **Chores**
  * Restrict CI runs to main branch and PR lifecycle events.
  * Add explicit build step before deployment.
  * Introduce deployment status tracking (pending → success/error) tied to publish outcome.
  * Use different publish behavior for main vs non-main builds.
  * Minor formatting cleanup in release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->