### PR TITLE
:bug: fix: specify the custom domain in Wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,12 @@
   "main": "src/entry.ts",
   "compatibility_date": "2026-04-27",
   "preview_urls": true,
+  "routes": [
+    {
+      "pattern": "quiz.clevertrevor.dev",
+      "custom_domain": true
+    }
+  ],
   "assets": {
     "binding": "ASSETS",
     "directory": "./public"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application is now accessible via the custom domain quiz.clevertrevor.dev.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->