### PR TITLE
:bug: fix: ProgramSelector navigation history

### DIFF
--- a/src/react-app/components/ProgramSelector.spec.tsx
+++ b/src/react-app/components/ProgramSelector.spec.tsx
@@ -1,3 +1,4 @@
+// src/react-app/components/ProgramSelector.spec.tsx
 import usePrograms from "@hooks/usePrograms";
 import { useNavigate } from "@tanstack/react-router";
 import { render, screen } from "@testing-library/react";
@@ -37,61 +38,47 @@ describe("ProgramSelector Component", () => {
 
   it("renders 'No programs found' when the programs array is empty", () => {
     (usePrograms as Mock).mockReturnValue({ programs: [] });
-
     render(<ProgramSelector />);
-
     expect(screen.getByText("No programs found")).toBeInTheDocument();
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
   });
 
-  it("renders the dropdown with the default placeholder when no programId is in the URL", () => {
-    render(<ProgramSelector />);
-
-    const selectElement = screen.getByRole("combobox") as HTMLSelectElement;
-    expect(selectElement).toBeInTheDocument();
-
-    expect(selectElement.value).toBe("");
-    expect(screen.getByText("Select your program")).toBeInTheDocument();
-    expect(screen.getByText("Program Alpha")).toBeInTheDocument();
-  });
-
-  it("pre-selects the correct option if programId exists in the URL parameters", () => {
+  it("pre-selects the correct option if programId exists and is valid", () => {
     (Route.useSearch as Mock).mockReturnValue({ programId: "2" });
 
     render(<ProgramSelector />);
 
     const selectElement = screen.getByRole("combobox") as HTMLSelectElement;
     expect(selectElement.value).toBe("2");
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("calls navigate with the updated search param when a new option is chosen", async () => {
+  it("clears the search parameter from the URL if programId does not match any existing program", () => {
+    (Route.useSearch as Mock).mockReturnValue({ programId: "ghost-id-999" });
+
     render(<ProgramSelector />);
 
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({
+      search: {},
+      replace: true,
+    });
+  });
+
+  it("calls navigate with the updated search param when a new option is chosen manually", async () => {
+    render(<ProgramSelector />);
     const selectElement = screen.getByRole("combobox");
 
     await userEvent.selectOptions(selectElement, "2");
 
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith({
       search: { programId: "2" },
+      replace: true,
     });
   });
 
   it("focuses the select element on initial mount", () => {
     render(<ProgramSelector />);
-
     const selectElement = screen.getByRole("combobox");
     expect(selectElement).toHaveFocus();
-  });
-
-  it("falls back to the placeholder if the URL programId does not exist in the data", () => {
-    (Route.useSearch as Mock).mockReturnValue({ programId: "ghost-id-999" });
-
-    render(<ProgramSelector />);
-
-    const selectElement = screen.getByRole("combobox") as HTMLSelectElement;
-
-    expect(selectElement.value).toBe("");
-    expect(screen.getByText("Select your program")).toBeInTheDocument();
   });
 });

--- a/src/react-app/components/ProgramSelector.tsx
+++ b/src/react-app/components/ProgramSelector.tsx
@@ -9,6 +9,17 @@ function ProgramSelector() {
   const { programId } = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
 
+  const isValidSelection = programs.some((p) => p.id === programId);
+
+  useEffect(() => {
+    if (programId && !isValidSelection) {
+      navigate({
+        search: {},
+        replace: true,
+      });
+    }
+  }, [programId, isValidSelection, navigate]);
+
   useEffect(() => {
     if (selectRef.current) {
       selectRef.current.focus();
@@ -30,6 +41,7 @@ function ProgramSelector() {
   const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     navigate({
       search: { programId: e.target.value },
+      replace: true,
     });
   };
 
@@ -38,7 +50,7 @@ function ProgramSelector() {
       <select
         ref={selectRef}
         onChange={handleSelect}
-        value={programs.some((p) => p.id === programId) ? programId : ""}
+        value={isValidSelection ? programId : ""}
       >
         <option value="" disabled hidden>
           Select your program

--- a/src/react-app/components/ProgramSelector.tsx
+++ b/src/react-app/components/ProgramSelector.tsx
@@ -12,13 +12,13 @@ function ProgramSelector() {
   const isValidSelection = programs.some((p) => p.id === programId);
 
   useEffect(() => {
-    if (programId && !isValidSelection) {
+    if (programId && programs.length > 0 && !isValidSelection) {
       navigate({
         search: {},
         replace: true,
       });
     }
-  }, [programId, isValidSelection, navigate]);
+  }, [programId, programs.length, isValidSelection, navigate]);
 
   useEffect(() => {
     if (selectRef.current) {


### PR DESCRIPTION
- **:white_check_mark: test: add coverage for self-healing URL**
- **:bug: fix: self-heal URL when unknown programId; replace valid ones**

Closes #75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid program selections in the URL are now automatically cleared when detected.
  * Switching between programs uses optimized navigation that avoids creating redundant browser history entries.
  * Program selector validation ensures the interface correctly displays valid selections and prevents inconsistent states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->