### PR TITLE
:sparkles: feat: AI clues phase one - DB Schema

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -36,6 +36,10 @@
 - No `console.log` in production code. Use structured logging if needed.
 - Imports: Biome handles organization. Do not manually sort.
 - No barrel files (`index.ts` re-exports) unless already established in that directory.
+- Double quotes for JS/TS strings
+- 2-space indentation, LF line endings, UTF-8, final newline (`.editorconfig`)
+- Max line length: 80 characters
+- TypeScript strict mode plus `noUnusedLocals`, `noUnusedParameters`, etc. — do not disable these
 
 ## Testing
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,19 +1,22 @@
 # terminal-quiz — Coding Conventions
 
 ## Environment
+
 - TypeScript strict mode. No `any` — use `unknown` and narrow explicitly.
 - Runtime: Cloudflare Workers (not Node.js). Do not use Node-only APIs (`fs`, `path`, `process.env` directly, etc.).
 - Package manager: pnpm. Never suggest npm or yarn commands.
 - Linter/formatter: Biome via `pnpm check:code`. Do not guess style; let the linter enforce it.
 
 ## Architecture
+
 - Full-stack SPA: React frontend + Hono backend, both running on Cloudflare Workers.
 - Database: Cloudflare D1 via Drizzle ORM. All schema changes go through Drizzle migrations.
 - Session state tracked in `session_progress` table — do not use KV for session data.
-- Routing is backend-driven. Route structure: `/`, `/programs/select`, `/programs/:programId`.
+- Routing is client-side (via TanStack Router) with backend fallback support. Route structure: /, /programs/select, /programs/:programId.
 - Do not introduce gate-level URLs or client-side route guards that duplicate server logic.
 
 ## Frontend
+
 - React functional components only. No class components.
 - TanStack Router for all routing. Use `createFileRoute`; do not use manual route objects.
 - Named exports preferred. Default exports only where TanStack Router file-based routing requires.
@@ -21,29 +24,34 @@
 - Adjust `staleTime` intentionally; do not leave it at 0 if it causes unnecessary refetches in tests.
 
 ## Backend
+
 - Hono for all API routes. Keep route handlers thin — business logic belongs in service functions.
 - GraphQL is used for the play flow. REST endpoints for the legacy flow remain untouched.
 - Do not modify the legacy REST flow unless the task explicitly requires it.
 - Validate all inputs at the Hono layer before touching D1.
 
 ## Code style
+
 - Prefer early returns over nested conditionals.
 - No `console.log` in production code. Use structured logging if needed.
 - Imports: Biome handles organization. Do not manually sort.
 - No barrel files (`index.ts` re-exports) unless already established in that directory.
 
 ## Testing
+
 - Vitest only. No Jest APIs.
 - Co-locate tests with source: `foo.test.ts` next to `foo.ts`.
 - Do not use real D1/Workers bindings in unit tests — mock at the service boundary.
-- `staleTime` adjustments to fix `ECONNREFUSED` in tests are acceptable and expected.
+- Ensure all network requests are fully mocked in tests (e.g., using MSW) to prevent connection errors.
 
 ## Git
+
 - Conventional commits with gitmoji prefix. Format: `<emoji> <type>(<scope>): <description>`
 - Never commit directly to `main`. Feature branches only.
 - Do not push unreviewed changes to `main` — prefer branch-and-reset if a bad push occurs.
 
 ## What NOT to do
+
 - Do not install new dependencies without asking first.
 - Do not change the Drizzle schema without explicit instruction.
 - Do not refactor the legacy REST flow.

--- a/migrations/0006_cooing_annihilus.sql
+++ b/migrations/0006_cooing_annihilus.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `gate_clues` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_progress_id` text NOT NULL,
+	`gate_id` text NOT NULL,
+	`clue_text` text NOT NULL,
+	`attempt_count_at_request` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`session_progress_id`) REFERENCES `session_progress`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`gate_id`) REFERENCES `gates`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+ALTER TABLE `session_progress` ADD `attempt_count` integer DEFAULT 0 NOT NULL;

--- a/migrations/0007_brown_garia.sql
+++ b/migrations/0007_brown_garia.sql
@@ -1,0 +1,18 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_gate_clues` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_progress_id` text NOT NULL,
+	`gate_id` text NOT NULL,
+	`clue_text` text NOT NULL,
+	`attempt_count_at_request` integer NOT NULL,
+	`created_at` integer DEFAULT (strftime('%s', 'now')) NOT NULL,
+	FOREIGN KEY (`session_progress_id`) REFERENCES `session_progress`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`gate_id`) REFERENCES `gates`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_gate_clues`("id", "session_progress_id", "gate_id", "clue_text", "attempt_count_at_request", "created_at") SELECT "id", "session_progress_id", "gate_id", "clue_text", "attempt_count_at_request", "created_at" FROM `gate_clues`;--> statement-breakpoint
+DROP TABLE `gate_clues`;--> statement-breakpoint
+ALTER TABLE `__new_gate_clues` RENAME TO `gate_clues`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `gate_clues_session_progress_id_idx` ON `gate_clues` (`session_progress_id`);--> statement-breakpoint
+CREATE INDEX `gate_clues_gate_id_idx` ON `gate_clues` (`gate_id`);

--- a/migrations/meta/0006_snapshot.json
+++ b/migrations/meta/0006_snapshot.json
@@ -1,0 +1,415 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "35ea0727-644f-43a7-83dd-2be1e7b05ada",
+  "prevId": "da8d0da7-a5ea-4f3a-81d3-4f10c14d0f9a",
+  "tables": {
+    "game_state": {
+      "name": "game_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gate_clues": {
+      "name": "gate_clues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clue_text": {
+          "name": "clue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count_at_request": {
+          "name": "attempt_count_at_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gate_clues_session_progress_id_session_progress_id_fk": {
+          "name": "gate_clues_session_progress_id_session_progress_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gate_clues_gate_id_gates_id_fk": {
+          "name": "gate_clues_gate_id_gates_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gates": {
+      "name": "gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success_message": {
+          "name": "success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_solved": {
+          "name": "is_solved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "solved_at": {
+          "name": "solved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.875
+        },
+        "guidance_enabled": {
+          "name": "guidance_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guidance_prompt": {
+          "name": "guidance_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guidance_threshold": {
+          "name": "guidance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {
+        "unique_program_sequence": {
+          "name": "unique_program_sequence",
+          "columns": ["program_id", "sequence_order"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gates_program_id_programs_id_fk": {
+          "name": "gates_program_id_programs_id_fk",
+          "tableFrom": "gates",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "programs": {
+      "name": "programs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_selected": {
+          "name": "is_selected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "selected_at": {
+          "name": "selected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_progress": {
+      "name": "session_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_gate_id": {
+          "name": "current_gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_gate_ids": {
+          "name": "completed_gate_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_session_progress": {
+          "name": "unique_session_progress",
+          "columns": ["session_id", "program_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_progress_program_id_programs_id_fk": {
+          "name": "session_progress_program_id_programs_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_progress_current_gate_id_gates_id_fk": {
+          "name": "session_progress_current_gate_id_gates_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "gates",
+          "columnsFrom": ["current_gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0007_snapshot.json
+++ b/migrations/meta/0007_snapshot.json
@@ -1,0 +1,427 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f458e278-5b7e-4d94-b85e-6ed2e3432de1",
+  "prevId": "35ea0727-644f-43a7-83dd-2be1e7b05ada",
+  "tables": {
+    "game_state": {
+      "name": "game_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gate_clues": {
+      "name": "gate_clues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clue_text": {
+          "name": "clue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count_at_request": {
+          "name": "attempt_count_at_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "gate_clues_session_progress_id_idx": {
+          "name": "gate_clues_session_progress_id_idx",
+          "columns": ["session_progress_id"],
+          "isUnique": false
+        },
+        "gate_clues_gate_id_idx": {
+          "name": "gate_clues_gate_id_idx",
+          "columns": ["gate_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gate_clues_session_progress_id_session_progress_id_fk": {
+          "name": "gate_clues_session_progress_id_session_progress_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gate_clues_gate_id_gates_id_fk": {
+          "name": "gate_clues_gate_id_gates_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gates": {
+      "name": "gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success_message": {
+          "name": "success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_solved": {
+          "name": "is_solved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "solved_at": {
+          "name": "solved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.875
+        },
+        "guidance_enabled": {
+          "name": "guidance_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guidance_prompt": {
+          "name": "guidance_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guidance_threshold": {
+          "name": "guidance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {
+        "unique_program_sequence": {
+          "name": "unique_program_sequence",
+          "columns": ["program_id", "sequence_order"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gates_program_id_programs_id_fk": {
+          "name": "gates_program_id_programs_id_fk",
+          "tableFrom": "gates",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "programs": {
+      "name": "programs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_selected": {
+          "name": "is_selected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "selected_at": {
+          "name": "selected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_progress": {
+      "name": "session_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_gate_id": {
+          "name": "current_gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_gate_ids": {
+          "name": "completed_gate_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_session_progress": {
+          "name": "unique_session_progress",
+          "columns": ["session_id", "program_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_progress_program_id_programs_id_fk": {
+          "name": "session_progress_program_id_programs_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_progress_current_gate_id_gates_id_fk": {
+          "name": "session_progress_current_gate_id_gates_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "gates",
+          "columnsFrom": ["current_gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782585554058,
       "tag": "0006_cooing_annihilus",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1782590427189,
+      "tag": "0007_brown_garia",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1781955928179,
       "tag": "0005_colossal_marrow",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1782585554058,
+      "tag": "0006_cooing_annihilus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -95,22 +95,30 @@ export const sessionProgress = sqliteTable(
   (t) => [unique("unique_session_progress").on(t.sessionId, t.programId)],
 );
 
-export const gateClues = sqliteTable("gate_clues", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  sessionProgressId: text("session_progress_id")
-    .notNull()
-    .references(() => sessionProgress.id, { onDelete: "cascade" }),
-  gateId: text("gate_id")
-    .notNull()
-    .references(() => gates.id, { onDelete: "cascade" }),
-  clueText: text("clue_text").notNull(),
-  attemptCountAtRequest: integer("attempt_count_at_request").notNull(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-});
+export const gateClues = sqliteTable(
+  "gate_clues",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    sessionProgressId: text("session_progress_id")
+      .notNull()
+      .references(() => sessionProgress.id, { onDelete: "cascade" }),
+    gateId: text("gate_id")
+      .notNull()
+      .references(() => gates.id, { onDelete: "cascade" }),
+    clueText: text("clue_text").notNull(),
+    attemptCountAtRequest: integer("attempt_count_at_request").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(strftime('%s', 'now'))`)
+      .$defaultFn(() => new Date()),
+  },
+  (t) => [
+    index("gate_clues_session_progress_id_idx").on(t.sessionProgressId),
+    index("gate_clues_gate_id_idx").on(t.gateId),
+  ],
+);
 
 export const programsRelations = relations(programs, ({ many }) => ({
   gates: many(gates),

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -1,10 +1,12 @@
 import { relations, sql } from "drizzle-orm";
 import {
+  index,
   integer,
   real,
   sqliteTable,
   text,
   unique,
+  sql,
 } from "drizzle-orm/sqlite-core";
 
 export const gates = sqliteTable(

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -3,10 +3,10 @@ import {
   index,
   integer,
   real,
+  sql,
   sqliteTable,
   text,
   unique,
-  sql,
 } from "drizzle-orm/sqlite-core";
 
 export const gates = sqliteTable(

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -56,44 +56,6 @@ export const programs = sqliteTable("programs", {
     .default(sql`(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))`),
 });
 
-export const programsRelations = relations(programs, ({ many }) => ({
-  gates: many(gates),
-}));
-
-export const gatesRelations = relations(gates, ({ one, many }) => ({
-  program: one(programs, {
-    fields: [gates.programId],
-    references: [programs.id],
-  }),
-  gateClues: many(gateClues),
-}));
-
-export const sessionProgressRelations = relations(
-  sessionProgress,
-  ({ one, many }) => ({
-    program: one(programs, {
-      fields: [sessionProgress.programId],
-      references: [programs.id],
-    }),
-    currentGate: one(gates, {
-      fields: [sessionProgress.currentGateId],
-      references: [gates.id],
-    }),
-    gateClues: many(gateClues),
-  }),
-);
-
-export const gateCluesRelations = relations(gateClues, ({ one }) => ({
-  sessionProgress: one(sessionProgress, {
-    fields: [gateClues.sessionProgressId],
-    references: [sessionProgress.id],
-  }),
-  gate: one(gates, {
-    fields: [gateClues.gateId],
-    references: [gates.id],
-  }),
-}));
-
 export const gameState = sqliteTable("game_state", {
   id: integer("id").primaryKey().default(1),
   lastUpdated: integer("last_updated", { mode: "timestamp" })
@@ -146,3 +108,41 @@ export const gateClues = sqliteTable("gate_clues", {
     .notNull()
     .$defaultFn(() => new Date()),
 });
+
+export const programsRelations = relations(programs, ({ many }) => ({
+  gates: many(gates),
+}));
+
+export const gatesRelations = relations(gates, ({ one, many }) => ({
+  program: one(programs, {
+    fields: [gates.programId],
+    references: [programs.id],
+  }),
+  gateClues: many(gateClues),
+}));
+
+export const sessionProgressRelations = relations(
+  sessionProgress,
+  ({ one, many }) => ({
+    program: one(programs, {
+      fields: [sessionProgress.programId],
+      references: [programs.id],
+    }),
+    currentGate: one(gates, {
+      fields: [sessionProgress.currentGateId],
+      references: [gates.id],
+    }),
+    gateClues: many(gateClues),
+  }),
+);
+
+export const gateCluesRelations = relations(gateClues, ({ one }) => ({
+  sessionProgress: one(sessionProgress, {
+    fields: [gateClues.sessionProgressId],
+    references: [sessionProgress.id],
+  }),
+  gate: one(gates, {
+    fields: [gateClues.gateId],
+    references: [gates.id],
+  }),
+}));

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -3,7 +3,6 @@ import {
   index,
   integer,
   real,
-  sql,
   sqliteTable,
   text,
   unique,

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -87,7 +87,8 @@ export const sessionProgress = sqliteTable(
       .$defaultFn(() => new Date())
       .$onUpdateFn(() => new Date()),
     completedAt: integer("completed_at", { mode: "timestamp" }),
-    attemptCount: integer("attempt_count").notNull().default(0), // Counter for incorrect guesses for the current gate
+    // Counter for incorrect guesses for the current gate
+    attemptCount: integer("attempt_count").notNull().default(0),
   },
   (t) => [unique("unique_session_progress").on(t.sessionId, t.programId)],
 );

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -60,10 +60,34 @@ export const programsRelations = relations(programs, ({ many }) => ({
   gates: many(gates),
 }));
 
-export const gatesRelations = relations(gates, ({ one }) => ({
+export const gatesRelations = relations(gates, ({ one, many }) => ({
   program: one(programs, {
     fields: [gates.programId],
     references: [programs.id],
+  }),
+  gateClues: many(gateClues),
+}));
+
+export const sessionProgressRelations = relations(sessionProgress, ({ one, many }) => ({
+  program: one(programs, {
+    fields: [sessionProgress.programId],
+    references: [programs.id],
+  }),
+  currentGate: one(gates, {
+    fields: [sessionProgress.currentGateId],
+    references: [gates.id],
+  }),
+  gateClues: many(gateClues),
+}));
+
+export const gateCluesRelations = relations(gateClues, ({ one }) => ({
+  sessionProgress: one(sessionProgress, {
+    fields: [gateClues.sessionProgressId],
+    references: [sessionProgress.id],
+  }),
+  gate: one(gates, {
+    fields: [gateClues.gateId],
+    references: [gates.id],
   }),
 }));
 
@@ -98,6 +122,16 @@ export const sessionProgress = sqliteTable(
       .$defaultFn(() => new Date())
       .$onUpdateFn(() => new Date()),
     completedAt: integer("completed_at", { mode: "timestamp" }),
+    attemptCount: integer("attempt_count").notNull().default(0), // Counter for incorrect guesses for the current gate
   },
   (t) => [unique("unique_session_progress").on(t.sessionId, t.programId)],
 );
+
+export const gateClues = sqliteTable("gate_clues", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  sessionProgressId: text("session_progress_id").notNull().references(() => sessionProgress.id, { onDelete: "cascade" }),
+  gateId: text("gate_id").notNull().references(() => gates.id, { onDelete: "cascade" }),
+  clueText: text("clue_text").notNull(),
+  attemptCountAtRequest: integer("attempt_count_at_request").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+});

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -68,17 +68,20 @@ export const gatesRelations = relations(gates, ({ one, many }) => ({
   gateClues: many(gateClues),
 }));
 
-export const sessionProgressRelations = relations(sessionProgress, ({ one, many }) => ({
-  program: one(programs, {
-    fields: [sessionProgress.programId],
-    references: [programs.id],
+export const sessionProgressRelations = relations(
+  sessionProgress,
+  ({ one, many }) => ({
+    program: one(programs, {
+      fields: [sessionProgress.programId],
+      references: [programs.id],
+    }),
+    currentGate: one(gates, {
+      fields: [sessionProgress.currentGateId],
+      references: [gates.id],
+    }),
+    gateClues: many(gateClues),
   }),
-  currentGate: one(gates, {
-    fields: [sessionProgress.currentGateId],
-    references: [gates.id],
-  }),
-  gateClues: many(gateClues),
-}));
+);
 
 export const gateCluesRelations = relations(gateClues, ({ one }) => ({
   sessionProgress: one(sessionProgress, {
@@ -128,10 +131,18 @@ export const sessionProgress = sqliteTable(
 );
 
 export const gateClues = sqliteTable("gate_clues", {
-  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
-  sessionProgressId: text("session_progress_id").notNull().references(() => sessionProgress.id, { onDelete: "cascade" }),
-  gateId: text("gate_id").notNull().references(() => gates.id, { onDelete: "cascade" }),
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  sessionProgressId: text("session_progress_id")
+    .notNull()
+    .references(() => sessionProgress.id, { onDelete: "cascade" }),
+  gateId: text("gate_id")
+    .notNull()
+    .references(() => gates.id, { onDelete: "cascade" }),
   clueText: text("clue_text").notNull(),
   attemptCountAtRequest: integer("attempt_count_at_request").notNull(),
-  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(() => new Date()),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
 });


### PR DESCRIPTION
- **:memo: docs: update conventions with corrections; fix whitespace**
- **:sparkles: feat(schema): add attemptCount to sessionProgress and gateClues table**
- **🧹 refactor(shared/schema): format schema file for readability**
- **🛠️ refactor(shared/schema): move relations after tables to fix order**
- **:hammer: chore: Add gate clues table**

Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking clue requests and attempt counts during gameplay.
  * Improved the app’s routing guidance to reflect client-side navigation with backend fallback.

* **Bug Fixes**
  * Better preserves session progress when recording gate-related clues and guesses.

* **Documentation**
  * Updated conventions to match the current routing approach and removed an outdated testing note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->