### PR TITLE
:sparkles: feat: AI clues backend

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-pnpm test
+pnpm test run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,8 @@ Dev server: `http://localhost:5173`.
 ## Common Commands
 
 ```bash
-pnpm test               # watch mode
+pnpm test run           # run tests once
 pnpm coverage           # single run with V8 coverage
-pnpm test:ui            # Vitest browser UI
 
 pnpm lint               # biome lint .
 pnpm format             # biome format --write .
@@ -169,8 +168,8 @@ Do **not** bypass hooks with `--no-verify` unless documented.
 Tests are co-located with source as `*.spec.ts` / `*.spec.tsx`. Shared helpers live in `src/react-app/test-utils/`; worker tests use plain Vitest with hand-built mock DB objects (no real D1 in unit tests).
 
 ```bash
-pnpm test          # watch mode
-pnpm coverage      # single run with V8 coverage
+pnpm test run          # run tests once
+pnpm coverage          # single run with V8 coverage
 ```
 
 **Stack:** Vitest, React Testing Library + happy-dom, MSW (HTTP mocking, e.g. GraphQL queries in `-select.spec.tsx`), `@testing-library/jest-dom`.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -52,6 +52,9 @@
 
 - Conventional commits with gitmoji prefix. Format: `<emoji> <type>(<scope>): <description>`
 - Never commit directly to `main`. Feature branches only.
+- Regarding scope: Always lowercase and kebab-case (e.g. ai-service, not aiService)
+- Regarding scope: Never include file extensions (e.g. ai-service, not ai-service.ts)
+- Regarding scope: Use the logical module name, not the filename
 - Do not push unreviewed changes to `main` — prefer branch-and-reset if a bad push occurs.
 
 ## What NOT to do

--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ src/
 ├── react-app/      # Vite-built SPA (served as static assets)
 │   ├── api/        # TanStack Query client/hooks, Hono RPC client
 │   ├── components/ # React components
-│   ├── hooks/       
+│   ├── hooks/
 │   ├── routes/      # TanStack file-based routes
-│   ├── utils/       
-│   └── test-utils/ 
+│   ├── utils/
+│   └── test-utils/
 ├── shared/
 │   ├── schema.ts   # Drizzle schema (single source of truth for DB + types)
-│   └── types.ts    
+│   └── types.ts
 └── worker/
-    ├── middleware/  
-    ├── routes/      
-    └── services/    
+    ├── middleware/
+    ├── routes/
+    └── services/
 ```
 
 **Request flow:**
@@ -139,8 +139,8 @@ pnpm seed:local      # Populate with initial program/gate data
 | `pnpm check` | Build and run a wrangler dry-run deploy (pre-deploy sanity check) |
 | `pnpm check:code` | Run Biome linting and formatting checks, auto-fixing where safe |
 | `pnpm test` | Run the Vitest test suite in watch mode |
+| `pnpm test run` | Run the Vitest test suite once |
 | `pnpm coverage` | Run the full test suite and generate a coverage report |
-| `pnpm test:ui` | Open the Vitest browser UI |
 | `pnpm commit` | Launch the interactive Commitizen prompt (preferred over `git commit`) |
 | `pnpm cf-typegen` | Regenerate Wrangler/Workers type bindings |
 
@@ -160,6 +160,7 @@ The project uses Vitest with happy-dom as the test environment.
 
 ```bash
 pnpm test          # Watch mode
+pnpm test:run      # Run tests once
 pnpm coverage      # Single run with coverage (outputs to ./coverage)
 pnpm test:ui       # Browser-based Vitest UI
 ```

--- a/migrations/0008_safe_mystique.sql
+++ b/migrations/0008_safe_mystique.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `unique_clue_per_attempt` ON `gate_clues` (`session_progress_id`,`gate_id`,`attempt_count_at_request`);

--- a/migrations/meta/0008_snapshot.json
+++ b/migrations/meta/0008_snapshot.json
@@ -1,0 +1,436 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "67fe7023-562f-402a-ac05-74bda844075c",
+  "prevId": "f458e278-5b7e-4d94-b85e-6ed2e3432de1",
+  "tables": {
+    "game_state": {
+      "name": "game_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gate_clues": {
+      "name": "gate_clues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clue_text": {
+          "name": "clue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count_at_request": {
+          "name": "attempt_count_at_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "gate_clues_session_progress_id_idx": {
+          "name": "gate_clues_session_progress_id_idx",
+          "columns": ["session_progress_id"],
+          "isUnique": false
+        },
+        "gate_clues_gate_id_idx": {
+          "name": "gate_clues_gate_id_idx",
+          "columns": ["gate_id"],
+          "isUnique": false
+        },
+        "unique_clue_per_attempt": {
+          "name": "unique_clue_per_attempt",
+          "columns": [
+            "session_progress_id",
+            "gate_id",
+            "attempt_count_at_request"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gate_clues_session_progress_id_session_progress_id_fk": {
+          "name": "gate_clues_session_progress_id_session_progress_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gate_clues_gate_id_gates_id_fk": {
+          "name": "gate_clues_gate_id_gates_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gates": {
+      "name": "gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success_message": {
+          "name": "success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_solved": {
+          "name": "is_solved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "solved_at": {
+          "name": "solved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.875
+        },
+        "guidance_enabled": {
+          "name": "guidance_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guidance_prompt": {
+          "name": "guidance_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guidance_threshold": {
+          "name": "guidance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {
+        "unique_program_sequence": {
+          "name": "unique_program_sequence",
+          "columns": ["program_id", "sequence_order"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gates_program_id_programs_id_fk": {
+          "name": "gates_program_id_programs_id_fk",
+          "tableFrom": "gates",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "programs": {
+      "name": "programs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_selected": {
+          "name": "is_selected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "selected_at": {
+          "name": "selected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_progress": {
+      "name": "session_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_gate_id": {
+          "name": "current_gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_gate_ids": {
+          "name": "completed_gate_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_session_progress": {
+          "name": "unique_session_progress",
+          "columns": ["session_id", "program_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_progress_program_id_programs_id_fk": {
+          "name": "session_progress_program_id_programs_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_progress_current_gate_id_gates_id_fk": {
+          "name": "session_progress_current_gate_id_gates_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "gates",
+          "columnsFrom": ["current_gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1782590427189,
       "tag": "0007_brown_garia",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1782680482300,
+      "tag": "0008_safe_mystique",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@cloudflare/vite-plugin": "^1.42.0",
-    "@cloudflare/workers-types": "^4.20260619.1",
+    "@cloudflare/workers-types": "^4.20260626.1",
     "@commitlint/cli": "^20.5.2",
     "@commitlint/types": "^20.5.0",
     "@semantic-release/git": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       drizzle-graphql:
         specifier: ^0.8.5
-        version: 0.8.5(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260619.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0))(graphql@16.14.2)
+        version: 0.8.5(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260626.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0))(graphql@16.14.2)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260619.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260626.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
       graphql:
         specifier: ^16.14.2
         version: 16.14.2
@@ -65,10 +65,10 @@ importers:
         version: 2.5.0
       '@cloudflare/vite-plugin':
         specifier: ^1.42.0
-        version: 1.42.0(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260617.1)(wrangler@4.102.0(@cloudflare/workers-types@4.20260619.1))
+        version: 1.42.0(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260617.1)(wrangler@4.102.0(@cloudflare/workers-types@4.20260626.1))
       '@cloudflare/workers-types':
-        specifier: ^4.20260619.1
-        version: 4.20260619.1
+        specifier: ^4.20260626.1
+        version: 4.20260626.1
       '@commitlint/cli':
         specifier: ^20.5.2
         version: 20.5.3(@types/node@24.13.2)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
@@ -173,7 +173,7 @@ importers:
         version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.6)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       wrangler:
         specifier: ^4.102.0
-        version: 4.102.0(@cloudflare/workers-types@4.20260619.1)
+        version: 4.102.0(@cloudflare/workers-types@4.20260626.1)
 
 packages:
 
@@ -374,8 +374,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260619.1':
-    resolution: {integrity: sha512-bprsNzG0DapQPFwU2AvQlQ6FUO7Y4bKWaPBzLNI7nBSqlHsK0P62xx2NaNT6i/htzAgQspKZm1D32y0RxofrRQ==}
+  '@cloudflare/workers-types@4.20260626.1':
+    resolution: {integrity: sha512-fBnpQyFRS3Ce1l2IUd3k+aUxgy/7VMlVXF4F672/eSrpXFeezCy3Ha6Z2uTyGgqu9sGvQPOj8nqKBv2yeI+ciw==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -3487,6 +3487,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   seroval-plugins@1.5.4:
     resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
     engines: {node: '>=10'}
@@ -4243,13 +4248,13 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260617.1
 
-  '@cloudflare/vite-plugin@1.42.0(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260617.1)(wrangler@4.102.0(@cloudflare/workers-types@4.20260619.1))':
+  '@cloudflare/vite-plugin@1.42.0(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260617.1)(wrangler@4.102.0(@cloudflare/workers-types@4.20260626.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)
       miniflare: 4.20260617.0
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
-      wrangler: 4.102.0(@cloudflare/workers-types@4.20260619.1)
+      wrangler: 4.102.0(@cloudflare/workers-types@4.20260626.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -4271,7 +4276,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260617.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260619.1': {}
+  '@cloudflare/workers-types@4.20260626.1': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -5827,9 +5832,9 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  drizzle-graphql@0.8.5(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260619.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0))(graphql@16.14.2):
+  drizzle-graphql@0.8.5(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260626.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0))(graphql@16.14.2):
     dependencies:
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260619.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260626.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
       graphql: 16.14.2
       graphql-parse-resolve-info: 4.14.1(graphql@16.14.2)
     transitivePeerDependencies:
@@ -5842,9 +5847,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.22.3
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260619.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260626.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0):
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260619.1
+      '@cloudflare/workers-types': 4.20260626.1
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.10.0
 
@@ -6714,7 +6719,7 @@ snapshots:
 
   node-abi@3.92.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
     optional: true
 
   node-emoji@1.11.0:
@@ -7128,6 +7133,9 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.4: {}
+
+  semver@7.8.5:
+    optional: true
 
   seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
@@ -7573,7 +7581,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260617.1
       '@cloudflare/workerd-windows-64': 1.20260617.1
 
-  wrangler@4.102.0(@cloudflare/workers-types@4.20260619.1):
+  wrangler@4.102.0(@cloudflare/workers-types@4.20260626.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)
@@ -7584,7 +7592,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260617.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260619.1
+      '@cloudflare/workers-types': 4.20260626.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -116,6 +116,11 @@ export const gateClues = sqliteTable(
   (t) => [
     index("gate_clues_session_progress_id_idx").on(t.sessionProgressId),
     index("gate_clues_gate_id_idx").on(t.gateId),
+    unique("unique_clue_per_attempt").on(
+      t.sessionProgressId,
+      t.gateId,
+      t.attemptCountAtRequest,
+    ),
   ],
 );
 

--- a/src/worker/graphql/gameplay/clueEligibility.ts
+++ b/src/worker/graphql/gameplay/clueEligibility.ts
@@ -1,0 +1,35 @@
+export const MAX_CLUES_PER_GATE = 3;
+
+export function computeCluesRemaining(existingClueCount: number): number {
+  return Math.max(0, MAX_CLUES_PER_GATE - existingClueCount);
+}
+
+export function computeCanRequestClue(params: {
+  isCorrectGuess: boolean;
+  guidanceEnabled: boolean;
+  attemptCount: number;
+  guidanceThreshold: number;
+  existingClueCount: number;
+  mostRecentClueAttemptCount: number | null;
+}): boolean {
+  const {
+    isCorrectGuess,
+    guidanceEnabled,
+    attemptCount,
+    guidanceThreshold,
+    existingClueCount,
+    mostRecentClueAttemptCount,
+  } = params;
+
+  if (isCorrectGuess) return false;
+  if (!guidanceEnabled) return false;
+  if (attemptCount < guidanceThreshold) return false;
+  if (existingClueCount >= MAX_CLUES_PER_GATE) return false;
+  if (
+    mostRecentClueAttemptCount !== null &&
+    attemptCount <= mostRecentClueAttemptCount
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -1,54 +1,88 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { submitGuess } from "./mutations";
+import { requestClue, submitGuess } from "./mutations";
 import type { AppGraphQLContext } from "./queries";
 
 vi.mock("../../utils/isGuessCloseEnough", () => ({
   default: vi.fn(),
 }));
 
+vi.mock("../../services/aiService", () => ({
+  generateClue: vi.fn(),
+}));
+
+import { generateClue } from "../../services/aiService";
 import isGuessCloseEnough from "../../utils/isGuessCloseEnough";
 
+type MockDb = {
+  query: {
+    sessionProgress: { findFirst: ReturnType<typeof vi.fn> };
+    gates: { findFirst: ReturnType<typeof vi.fn> };
+    gateClues: { findMany: ReturnType<typeof vi.fn> };
+  };
+  update: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+};
+
+function createMockDb(): MockDb {
+  return {
+    query: {
+      sessionProgress: { findFirst: vi.fn() },
+      gates: { findFirst: vi.fn() },
+      gateClues: { findMany: vi.fn().mockResolvedValue([]) },
+    },
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+}
+
+function createMockContext(mockDb: MockDb): AppGraphQLContext {
+  return {
+    get: vi.fn((key: string) => {
+      if (key === "db") return mockDb;
+      if (key === "sessionId") return "mock-session-123";
+      return undefined;
+    }),
+  } as unknown as AppGraphQLContext;
+}
+
+const defaultGate = {
+  id: "gate-1",
+  correctAnswer: "apple",
+  sequenceOrder: 1,
+  successMessage: "OK",
+  guidanceEnabled: true,
+  guidanceThreshold: 2,
+  question: "What fruit keeps the doctor away?",
+};
+
+const defaultProgress = {
+  id: "progress-1",
+  status: "in_progress",
+  currentGateId: "gate-1",
+  completedGateIds: "[]",
+  attemptCount: 0,
+};
+
 describe("Gameplay Mutations: submitGuess", () => {
-  let mockDb: unknown;
+  let mockDb: MockDb;
   let mockContext: AppGraphQLContext;
 
   beforeEach(() => {
-    mockDb = {
-      query: {
-        sessionProgress: { findFirst: vi.fn() },
-        gates: { findFirst: vi.fn() },
-      },
-      update: vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined),
-        }),
-      }),
-    } as unknown;
-
-    mockContext = {
-      get: vi.fn((key: string) => {
-        if (key === "db") return mockDb;
-        if (key === "sessionId") return "mock-session-123";
-        return undefined;
-      }),
-    } as unknown as AppGraphQLContext;
+    mockDb = createMockDb();
+    mockContext = createMockContext(mockDb);
+    vi.mocked(isGuessCloseEnough).mockReset();
+    vi.mocked(generateClue).mockReset();
   });
 
-  it("returns false and does not update DB if guess is incorrect", async () => {
-    // @ts-expect-error - mocking nested functions safely for tests
-    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      id: "progress-1",
-      status: "in_progress",
-      currentGateId: "gate-1",
-      completedGateIds: "[]",
-    });
-    // @ts-expect-error
-    mockDb.query.gates.findFirst.mockResolvedValue({
-      id: "gate-1",
-      correctAnswer: "apple",
-      sequenceOrder: 1,
-      successMessage: "OK",
-    });
+  it("returns false and increments attemptCount if guess is incorrect", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue(defaultProgress);
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
     vi.mocked(isGuessCloseEnough).mockReturnValue(false);
 
     if (!submitGuess.resolve) throw new Error("Resolver not defined");
@@ -60,25 +94,137 @@ describe("Gameplay Mutations: submitGuess", () => {
     );
 
     expect(result.success).toBe(false);
-    // @ts-expect-error - mocking nested functions
-    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(result.canRequestClue).toBe(false);
+    expect(mockDb.update).toHaveBeenCalled();
+    const setCall = mockDb.update.mock.results[0]?.value.set;
+    expect(setCall).toHaveBeenCalledWith({ attemptCount: 1 });
   });
 
-  it("returns true and updates DB if guess is correct", async () => {
-    // @ts-expect-error
+  it("returns canRequestClue true when guidance threshold is met", async () => {
     mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      id: "progress-2",
-      status: "in_progress",
-      currentGateId: "gate-2",
-      completedGateIds: "[]",
+      ...defaultProgress,
+      attemptCount: 1,
     });
-    // @ts-expect-error
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([]);
+    vi.mocked(isGuessCloseEnough).mockReturnValue(false);
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    const result = await submitGuess.resolve(
+      null,
+      { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+      mockContext,
+    );
+
+    expect(result.canRequestClue).toBe(true);
+  });
+
+  it("returns canRequestClue false when guidance is disabled", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 5,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue({
+      ...defaultGate,
+      guidanceEnabled: false,
+    });
+    mockDb.query.gateClues.findMany.mockResolvedValue([]);
+    vi.mocked(isGuessCloseEnough).mockReturnValue(false);
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    const result = await submitGuess.resolve(
+      null,
+      { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+      mockContext,
+    );
+
+    expect(result.canRequestClue).toBe(false);
+  });
+
+  it("returns canRequestClue false when max clues reached", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 5,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([
+      { attemptCountAtRequest: 2 },
+      { attemptCountAtRequest: 3 },
+      { attemptCountAtRequest: 4 },
+    ]);
+    vi.mocked(isGuessCloseEnough).mockReturnValue(false);
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    const result = await submitGuess.resolve(
+      null,
+      { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+      mockContext,
+    );
+
+    expect(result.canRequestClue).toBe(false);
+  });
+
+  it("returns canRequestClue false when no new attempt since last clue", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 2,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([
+      { attemptCountAtRequest: 3 },
+    ]);
+    vi.mocked(isGuessCloseEnough).mockReturnValue(false);
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    const result = await submitGuess.resolve(
+      null,
+      { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+      mockContext,
+    );
+
+    expect(result.canRequestClue).toBe(false);
+  });
+
+  it("returns canRequestClue true after a new attempt since last clue", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 3,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([
+      { attemptCountAtRequest: 3 },
+    ]);
+    vi.mocked(isGuessCloseEnough).mockReturnValue(false);
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    const result = await submitGuess.resolve(
+      null,
+      { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+      mockContext,
+    );
+
+    expect(result.canRequestClue).toBe(true);
+  });
+
+  it("returns true, resets attemptCount, and sets canRequestClue false on correct guess", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      currentGateId: "gate-2",
+      attemptCount: 4,
+    });
     mockDb.query.gates.findFirst
       .mockResolvedValueOnce({
         id: "gate-2",
         correctAnswer: "banana",
         sequenceOrder: 2,
         successMessage: "Well done!",
+        guidanceEnabled: true,
+        guidanceThreshold: 2,
       })
       .mockResolvedValueOnce(null);
     vi.mocked(isGuessCloseEnough).mockReturnValue(true);
@@ -92,7 +238,257 @@ describe("Gameplay Mutations: submitGuess", () => {
     );
 
     expect(result.success).toBe(true);
-    // @ts-expect-error
-    expect(mockDb.update).toHaveBeenCalled();
+    expect(result.canRequestClue).toBe(false);
+    const setCall = mockDb.update.mock.results[0]?.value.set;
+    expect(setCall).toHaveBeenCalledWith(
+      expect.objectContaining({ attemptCount: 0 }),
+    );
+  });
+});
+
+describe("Gameplay Mutations: requestClue", () => {
+  let mockDb: MockDb;
+  let mockContext: AppGraphQLContext;
+
+  beforeEach(() => {
+    mockDb = createMockDb();
+    mockContext = createMockContext(mockDb);
+    vi.mocked(generateClue).mockReset();
+  });
+
+  it("throws when session ID is missing", async () => {
+    const contextWithoutSession = {
+      get: vi.fn((key: string) => {
+        if (key === "db") return mockDb;
+        return undefined;
+      }),
+    } as unknown as AppGraphQLContext;
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      requestClue.resolve(
+        null,
+        {
+          programId: "prog-1",
+          gateId: "gate-1",
+          currentGuess: "banana",
+        },
+        contextWithoutSession,
+      ),
+    ).rejects.toThrow("Unauthorized: Missing Session ID");
+  });
+
+  it("throws when gate ID does not match current gate", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      currentGateId: "gate-other",
+    });
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      requestClue.resolve(
+        null,
+        {
+          programId: "prog-1",
+          gateId: "gate-1",
+          currentGuess: "banana",
+        },
+        mockContext,
+      ),
+    ).rejects.toThrow("Desync: Clue requested for the wrong active gate.");
+  });
+
+  it("returns no clue when guidance is disabled", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 5,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue({
+      ...defaultGate,
+      guidanceEnabled: false,
+    });
+    mockDb.query.gateClues.findMany.mockResolvedValue([]);
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    const result = await requestClue.resolve(
+      null,
+      {
+        programId: "prog-1",
+        gateId: "gate-1",
+        currentGuess: "banana",
+      },
+      mockContext,
+    );
+
+    expect(result).toEqual({
+      clueText: null,
+      isClueLimitReached: false,
+      cluesRemaining: 3,
+    });
+    expect(generateClue).not.toHaveBeenCalled();
+  });
+
+  it("returns clue limit reached when max clues exist", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 10,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([
+      { clueText: "clue 1", attemptCountAtRequest: 2 },
+      { clueText: "clue 2", attemptCountAtRequest: 4 },
+      { clueText: "clue 3", attemptCountAtRequest: 6 },
+    ]);
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    const result = await requestClue.resolve(
+      null,
+      {
+        programId: "prog-1",
+        gateId: "gate-1",
+        currentGuess: "banana",
+      },
+      mockContext,
+    );
+
+    expect(result).toEqual({
+      clueText: null,
+      isClueLimitReached: true,
+      cluesRemaining: 0,
+    });
+    expect(generateClue).not.toHaveBeenCalled();
+  });
+
+  it("returns no clue when one-clue-per-attempt rule is not met", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 3,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([
+      { clueText: "clue 1", attemptCountAtRequest: 3 },
+    ]);
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    const result = await requestClue.resolve(
+      null,
+      {
+        programId: "prog-1",
+        gateId: "gate-1",
+        currentGuess: "banana",
+      },
+      mockContext,
+    );
+
+    expect(result.clueText).toBeNull();
+    expect(result.isClueLimitReached).toBe(false);
+    expect(generateClue).not.toHaveBeenCalled();
+  });
+
+  it("generates, persists, and returns a new clue when eligible", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 3,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([
+      { clueText: "Think about doctors.", attemptCountAtRequest: 2 },
+    ]);
+    vi.mocked(generateClue).mockResolvedValue("It is often red or green.");
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    const result = await requestClue.resolve(
+      null,
+      {
+        programId: "prog-1",
+        gateId: "gate-1",
+        currentGuess: "banana",
+      },
+      mockContext,
+    );
+
+    expect(generateClue).toHaveBeenCalledWith(
+      mockContext,
+      defaultGate.question,
+      defaultGate.correctAnswer,
+      "banana",
+      ["Think about doctors."],
+    );
+    expect(mockDb.insert).toHaveBeenCalled();
+    const valuesCall = mockDb.insert.mock.results[0]?.value.values;
+    expect(valuesCall).toHaveBeenCalledWith({
+      sessionProgressId: "progress-1",
+      gateId: "gate-1",
+      clueText: "It is often red or green.",
+      attemptCountAtRequest: 3,
+    });
+    expect(result).toEqual({
+      clueText: "It is often red or green.",
+      isClueLimitReached: false,
+      cluesRemaining: 1,
+    });
+  });
+
+  it("returns no clue when AI generation fails", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 2,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([]);
+    vi.mocked(generateClue).mockResolvedValue(null);
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    const result = await requestClue.resolve(
+      null,
+      {
+        programId: "prog-1",
+        gateId: "gate-1",
+        currentGuess: "banana",
+      },
+      mockContext,
+    );
+
+    expect(result.clueText).toBeNull();
+    expect(result.isClueLimitReached).toBe(false);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("marks clue limit reached after the third clue is generated", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 8,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([
+      { clueText: "clue 1", attemptCountAtRequest: 2 },
+      { clueText: "clue 2", attemptCountAtRequest: 5 },
+    ]);
+    vi.mocked(generateClue).mockResolvedValue("Final hint.");
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    const result = await requestClue.resolve(
+      null,
+      {
+        programId: "prog-1",
+        gateId: "gate-1",
+        currentGuess: "banana",
+      },
+      mockContext,
+    );
+
+    expect(result).toEqual({
+      clueText: "Final hint.",
+      isClueLimitReached: true,
+      cluesRemaining: 0,
+    });
   });
 });

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -81,7 +81,12 @@ describe("Gameplay Mutations: submitGuess", () => {
   });
 
   it("returns false and increments attemptCount if guess is incorrect", async () => {
-    mockDb.query.sessionProgress.findFirst.mockResolvedValue(defaultProgress);
+    mockDb.query.sessionProgress.findFirst
+      .mockResolvedValueOnce(defaultProgress)
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 1,
+      });
     mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
     vi.mocked(isGuessCloseEnough).mockReturnValue(false);
 
@@ -97,14 +102,23 @@ describe("Gameplay Mutations: submitGuess", () => {
     expect(result.canRequestClue).toBe(false);
     expect(mockDb.update).toHaveBeenCalled();
     const setCall = mockDb.update.mock.results[0]?.value.set;
-    expect(setCall).toHaveBeenCalledWith({ attemptCount: 1 });
+    expect(setCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attemptCount: expect.anything(),
+      }),
+    );
   });
 
   it("returns canRequestClue true when guidance threshold is met", async () => {
-    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      ...defaultProgress,
-      attemptCount: 1,
-    });
+    mockDb.query.sessionProgress.findFirst
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 1,
+      })
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 2,
+      });
     mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
     mockDb.query.gateClues.findMany.mockResolvedValue([]);
     vi.mocked(isGuessCloseEnough).mockReturnValue(false);
@@ -121,10 +135,15 @@ describe("Gameplay Mutations: submitGuess", () => {
   });
 
   it("returns canRequestClue false when guidance is disabled", async () => {
-    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      ...defaultProgress,
-      attemptCount: 5,
-    });
+    mockDb.query.sessionProgress.findFirst
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 5,
+      })
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 6,
+      });
     mockDb.query.gates.findFirst.mockResolvedValue({
       ...defaultGate,
       guidanceEnabled: false,
@@ -144,10 +163,15 @@ describe("Gameplay Mutations: submitGuess", () => {
   });
 
   it("returns canRequestClue false when max clues reached", async () => {
-    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      ...defaultProgress,
-      attemptCount: 5,
-    });
+    mockDb.query.sessionProgress.findFirst
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 5,
+      })
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 6,
+      });
     mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
     mockDb.query.gateClues.findMany.mockResolvedValue([
       { attemptCountAtRequest: 2 },
@@ -168,10 +192,15 @@ describe("Gameplay Mutations: submitGuess", () => {
   });
 
   it("returns canRequestClue false when no new attempt since last clue", async () => {
-    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      ...defaultProgress,
-      attemptCount: 2,
-    });
+    mockDb.query.sessionProgress.findFirst
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 2,
+      })
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 3,
+      });
     mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
     mockDb.query.gateClues.findMany.mockResolvedValue([
       { attemptCountAtRequest: 3 },
@@ -190,10 +219,15 @@ describe("Gameplay Mutations: submitGuess", () => {
   });
 
   it("returns canRequestClue true after a new attempt since last clue", async () => {
-    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      ...defaultProgress,
-      attemptCount: 3,
-    });
+    mockDb.query.sessionProgress.findFirst
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 3,
+      })
+      .mockResolvedValueOnce({
+        ...defaultProgress,
+        attemptCount: 4,
+      });
     mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
     mockDb.query.gateClues.findMany.mockResolvedValue([
       { attemptCountAtRequest: 3 },
@@ -300,6 +334,38 @@ describe("Gameplay Mutations: requestClue", () => {
     ).rejects.toThrow("Desync: Clue requested for the wrong active gate.");
   });
 
+  it("throws when currentGuess is empty", async () => {
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      requestClue.resolve(
+        null,
+        {
+          programId: "prog-1",
+          gateId: "gate-1",
+          currentGuess: "   ",
+        },
+        mockContext,
+      ),
+    ).rejects.toThrow("Invalid current guess length.");
+  });
+
+  it("throws when currentGuess exceeds max length", async () => {
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      requestClue.resolve(
+        null,
+        {
+          programId: "prog-1",
+          gateId: "gate-1",
+          currentGuess: "a".repeat(501),
+        },
+        mockContext,
+      ),
+    ).rejects.toThrow("Invalid current guess length.");
+  });
+
   it("returns no clue when guidance is disabled", async () => {
     mockDb.query.sessionProgress.findFirst.mockResolvedValue({
       ...defaultProgress,
@@ -397,7 +463,8 @@ describe("Gameplay Mutations: requestClue", () => {
     });
     mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
     mockDb.query.gateClues.findMany.mockResolvedValue([
-      { clueText: "Think about doctors.", attemptCountAtRequest: 2 },
+      { clueText: "It grows on trees.", attemptCountAtRequest: 2 },
+      { clueText: "Think about doctors.", attemptCountAtRequest: 1 },
     ]);
     vi.mocked(generateClue).mockResolvedValue("It is often red or green.");
 
@@ -418,7 +485,7 @@ describe("Gameplay Mutations: requestClue", () => {
       defaultGate.question,
       defaultGate.correctAnswer,
       "banana",
-      ["Think about doctors."],
+      ["Think about doctors.", "It grows on trees."],
     );
     expect(mockDb.insert).toHaveBeenCalled();
     const valuesCall = mockDb.insert.mock.results[0]?.value.values;
@@ -430,8 +497,8 @@ describe("Gameplay Mutations: requestClue", () => {
     });
     expect(result).toEqual({
       clueText: "It is often red or green.",
-      isClueLimitReached: false,
-      cluesRemaining: 1,
+      isClueLimitReached: true,
+      cluesRemaining: 0,
     });
   });
 

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -1,9 +1,31 @@
-import { gates, sessionProgress } from "@shared/schema";
-import { and, asc, eq, gt } from "drizzle-orm";
+import type * as schema from "@shared/schema";
+import { gateClues, gates, sessionProgress } from "@shared/schema";
+import { and, asc, desc, eq, gt } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { GraphQLNonNull, GraphQLString } from "graphql";
+import { generateClue } from "../../services/aiService";
 import isGuessCloseEnough from "../../utils/isGuessCloseEnough";
+import {
+  computeCanRequestClue,
+  computeCluesRemaining,
+  MAX_CLUES_PER_GATE,
+} from "./clueEligibility";
 import type { AppGraphQLContext } from "./queries";
-import { SubmitGuessPayloadType } from "./types";
+import { RequestClueResultType, SubmitGuessPayloadType } from "./types";
+
+async function getExistingCluesForGate(
+  db: DrizzleD1Database<typeof schema>,
+  sessionProgressId: string,
+  gateId: string,
+) {
+  return db.query.gateClues.findMany({
+    where: and(
+      eq(gateClues.sessionProgressId, sessionProgressId),
+      eq(gateClues.gateId, gateId),
+    ),
+    orderBy: [desc(gateClues.createdAt)],
+  });
+}
 
 export const submitGuess = {
   type: SubmitGuessPayloadType,
@@ -48,10 +70,35 @@ export const submitGuess = {
     }
 
     if (!isGuessCloseEnough(args.guess, activeGate.correctAnswer)) {
+      const newAttemptCount = progress.attemptCount + 1;
+
+      await db
+        .update(sessionProgress)
+        .set({ attemptCount: newAttemptCount })
+        .where(eq(sessionProgress.id, progress.id));
+
+      const existingClues = await getExistingCluesForGate(
+        db,
+        progress.id,
+        args.gateId,
+      );
+      const mostRecentClueAttemptCount =
+        existingClues[0]?.attemptCountAtRequest ?? null;
+
+      const canRequestClue = computeCanRequestClue({
+        isCorrectGuess: false,
+        guidanceEnabled: activeGate.guidanceEnabled,
+        attemptCount: newAttemptCount,
+        guidanceThreshold: activeGate.guidanceThreshold,
+        existingClueCount: existingClues.length,
+        mostRecentClueAttemptCount,
+      });
+
       return {
         success: false,
         message: "ACCESS DENIED. INCORRECT SYNTAX OR VALUE.",
         nextGate: null,
+        canRequestClue,
       };
     }
 
@@ -87,6 +134,7 @@ export const submitGuess = {
         currentGateId: nextGate ? nextGate.id : null,
         completedGateIds: JSON.stringify(completedIds),
         status: newStatus,
+        attemptCount: 0,
         ...(newStatus === "completed" ? { completedAt: new Date() } : {}),
       })
       .where(eq(sessionProgress.id, progress.id));
@@ -95,6 +143,127 @@ export const submitGuess = {
       success: true,
       message: activeGate.successMessage,
       nextGate,
+      canRequestClue: false,
+    };
+  },
+};
+
+export const requestClue = {
+  type: RequestClueResultType,
+  args: {
+    programId: { type: new GraphQLNonNull(GraphQLString) },
+    gateId: { type: new GraphQLNonNull(GraphQLString) },
+    currentGuess: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  resolve: async (
+    _: unknown,
+    args: { programId: string; gateId: string; currentGuess: string },
+    context: AppGraphQLContext,
+  ) => {
+    const db = context.get("db");
+    const sessionId = context.get("sessionId");
+
+    if (!sessionId) throw new Error("Unauthorized: Missing Session ID");
+
+    const progress = await db.query.sessionProgress.findFirst({
+      where: and(
+        eq(sessionProgress.sessionId, sessionId),
+        eq(sessionProgress.programId, args.programId),
+      ),
+    });
+
+    if (!progress || progress.status === "completed") {
+      throw new Error(
+        "Invalid state: Program already completed or not started.",
+      );
+    }
+
+    if (progress.currentGateId !== args.gateId) {
+      throw new Error("Desync: Clue requested for the wrong active gate.");
+    }
+
+    const activeGate = await db.query.gates.findFirst({
+      where: eq(gates.id, args.gateId),
+    });
+
+    if (!activeGate) {
+      throw new Error(`Gate with ID ${args.gateId} not found.`);
+    }
+
+    const existingClues = await getExistingCluesForGate(
+      db,
+      progress.id,
+      args.gateId,
+    );
+    const cluesRemaining = computeCluesRemaining(existingClues.length);
+    const mostRecentClueAttemptCount =
+      existingClues[0]?.attemptCountAtRequest ?? null;
+
+    if (!activeGate.guidanceEnabled) {
+      return {
+        clueText: null,
+        isClueLimitReached: false,
+        cluesRemaining,
+      };
+    }
+
+    if (existingClues.length >= MAX_CLUES_PER_GATE) {
+      return {
+        clueText: null,
+        isClueLimitReached: true,
+        cluesRemaining: 0,
+      };
+    }
+
+    if (
+      mostRecentClueAttemptCount !== null &&
+      progress.attemptCount <= mostRecentClueAttemptCount
+    ) {
+      return {
+        clueText: null,
+        isClueLimitReached: false,
+        cluesRemaining,
+      };
+    }
+
+    if (progress.attemptCount < activeGate.guidanceThreshold) {
+      return {
+        clueText: null,
+        isClueLimitReached: false,
+        cluesRemaining,
+      };
+    }
+
+    const previousClueTexts = existingClues.map((clue) => clue.clueText);
+    const clueText = await generateClue(
+      context,
+      activeGate.question,
+      activeGate.correctAnswer,
+      args.currentGuess,
+      previousClueTexts,
+    );
+
+    if (!clueText) {
+      return {
+        clueText: null,
+        isClueLimitReached: false,
+        cluesRemaining,
+      };
+    }
+
+    await db.insert(gateClues).values({
+      sessionProgressId: progress.id,
+      gateId: args.gateId,
+      clueText,
+      attemptCountAtRequest: progress.attemptCount,
+    });
+
+    const newCluesRemaining = computeCluesRemaining(existingClues.length + 1);
+
+    return {
+      clueText,
+      isClueLimitReached: newCluesRemaining === 0,
+      cluesRemaining: newCluesRemaining,
     };
   },
 };

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -234,7 +234,9 @@ export const requestClue = {
       };
     }
 
-    const previousClueTexts = existingClues.map((clue) => clue.clueText);
+    const previousClueTexts = existingClues
+      .toReversed()
+      .map((clue) => clue.clueText);
     const clueText = await generateClue(
       context,
       activeGate.question,

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -1,5 +1,5 @@
 import { gateClues, gates, sessionProgress } from "@shared/schema";
-import { and, asc, desc, eq, gt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, sql } from "drizzle-orm";
 import { GraphQLNonNull, GraphQLString } from "graphql";
 import { generateClue } from "../../services/aiService";
 import isGuessCloseEnough from "../../utils/isGuessCloseEnough";
@@ -68,12 +68,22 @@ export const submitGuess = {
     }
 
     if (!isGuessCloseEnough(args.guess, activeGate.correctAnswer)) {
-      const newAttemptCount = progress.attemptCount + 1;
-
+      // Atomic increment of attemptCount to prevent race conditions
       await db
         .update(sessionProgress)
-        .set({ attemptCount: newAttemptCount })
+        .set({
+          attemptCount: sql`${sessionProgress.attemptCount} + 1`,
+        })
         .where(eq(sessionProgress.id, progress.id));
+
+      // Re-fetch to get the incremented value
+      const updatedProgress = await db.query.sessionProgress.findFirst({
+        where: eq(sessionProgress.id, progress.id),
+      });
+
+      if (!updatedProgress) {
+        throw new Error("Failed to update attempt count.");
+      }
 
       const existingClues = await getExistingCluesForGate(
         db,
@@ -86,7 +96,7 @@ export const submitGuess = {
       const canRequestClue = computeCanRequestClue({
         isCorrectGuess: false,
         guidanceEnabled: activeGate.guidanceEnabled,
-        attemptCount: newAttemptCount,
+        attemptCount: updatedProgress.attemptCount,
         guidanceThreshold: activeGate.guidanceThreshold,
         existingClueCount: existingClues.length,
         mostRecentClueAttemptCount,
@@ -161,6 +171,15 @@ export const requestClue = {
     const db = context.get("db");
     const sessionId = context.get("sessionId");
 
+    const MAX_CURRENT_GUESS_LENGTH = 500;
+    const currentGuess = args.currentGuess.trim();
+    if (
+      currentGuess.length === 0 ||
+      currentGuess.length > MAX_CURRENT_GUESS_LENGTH
+    ) {
+      throw new Error("Invalid current guess length.");
+    }
+
     if (!sessionId) throw new Error("Unauthorized: Missing Session ID");
 
     const progress = await db.query.sessionProgress.findFirst({
@@ -197,37 +216,20 @@ export const requestClue = {
     const mostRecentClueAttemptCount =
       existingClues[0]?.attemptCountAtRequest ?? null;
 
-    if (!activeGate.guidanceEnabled) {
-      return {
-        clueText: null,
-        isClueLimitReached: false,
-        cluesRemaining,
-      };
-    }
+    // Use shared helper to check eligibility
+    const canRequestClue = computeCanRequestClue({
+      isCorrectGuess: false,
+      guidanceEnabled: activeGate.guidanceEnabled,
+      attemptCount: progress.attemptCount,
+      guidanceThreshold: activeGate.guidanceThreshold,
+      existingClueCount: existingClues.length,
+      mostRecentClueAttemptCount,
+    });
 
-    if (existingClues.length >= MAX_CLUES_PER_GATE) {
+    if (!canRequestClue) {
       return {
         clueText: null,
-        isClueLimitReached: true,
-        cluesRemaining: 0,
-      };
-    }
-
-    if (
-      mostRecentClueAttemptCount !== null &&
-      progress.attemptCount <= mostRecentClueAttemptCount
-    ) {
-      return {
-        clueText: null,
-        isClueLimitReached: false,
-        cluesRemaining,
-      };
-    }
-
-    if (progress.attemptCount < activeGate.guidanceThreshold) {
-      return {
-        clueText: null,
-        isClueLimitReached: false,
+        isClueLimitReached: existingClues.length >= MAX_CLUES_PER_GATE,
         cluesRemaining,
       };
     }
@@ -239,7 +241,7 @@ export const requestClue = {
       context,
       activeGate.question,
       activeGate.correctAnswer,
-      args.currentGuess,
+      currentGuess,
       previousClueTexts,
     );
 
@@ -251,12 +253,23 @@ export const requestClue = {
       };
     }
 
-    await db.insert(gateClues).values({
-      sessionProgressId: progress.id,
-      gateId: args.gateId,
-      clueText,
-      attemptCountAtRequest: progress.attemptCount,
-    });
+    try {
+      await db.insert(gateClues).values({
+        sessionProgressId: progress.id,
+        gateId: args.gateId,
+        clueText,
+        attemptCountAtRequest: progress.attemptCount,
+      });
+    } catch (error) {
+      // Handle unique constraint violation - another request
+      // may have already inserted a clue for this attempt
+      console.warn("Failed to insert clue (likely duplicate):", error);
+      return {
+        clueText: null,
+        isClueLimitReached: false,
+        cluesRemaining,
+      };
+    }
 
     const newCluesRemaining = computeCluesRemaining(existingClues.length + 1);
 

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -1,7 +1,5 @@
-import type * as schema from "@shared/schema";
 import { gateClues, gates, sessionProgress } from "@shared/schema";
 import { and, asc, desc, eq, gt } from "drizzle-orm";
-import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { GraphQLNonNull, GraphQLString } from "graphql";
 import { generateClue } from "../../services/aiService";
 import isGuessCloseEnough from "../../utils/isGuessCloseEnough";
@@ -14,7 +12,7 @@ import type { AppGraphQLContext } from "./queries";
 import { RequestClueResultType, SubmitGuessPayloadType } from "./types";
 
 async function getExistingCluesForGate(
-  db: DrizzleD1Database<typeof schema>,
+  db: AppGraphQLContext["var"]["db"],
   sessionProgressId: string,
   gateId: string,
 ) {

--- a/src/worker/graphql/gameplay/types.ts
+++ b/src/worker/graphql/gameplay/types.ts
@@ -1,5 +1,6 @@
 import {
   GraphQLBoolean,
+  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -45,7 +46,21 @@ const SubmitGuessPayloadType = new GraphQLObjectType({
     success: { type: new GraphQLNonNull(GraphQLBoolean) },
     message: { type: GraphQLString }, // Dynamic hint or success text
     nextGate: { type: ActiveGateType }, // Nullable if completed
+    canRequestClue: { type: new GraphQLNonNull(GraphQLBoolean) },
   },
 });
 
-export { ProgressionPayloadType, SubmitGuessPayloadType };
+const RequestClueResultType = new GraphQLObjectType({
+  name: "RequestClueResult",
+  fields: {
+    clueText: { type: GraphQLString },
+    isClueLimitReached: { type: new GraphQLNonNull(GraphQLBoolean) },
+    cluesRemaining: { type: new GraphQLNonNull(GraphQLInt) },
+  },
+});
+
+export {
+  ProgressionPayloadType,
+  RequestClueResultType,
+  SubmitGuessPayloadType,
+};

--- a/src/worker/routes/graphql.ts
+++ b/src/worker/routes/graphql.ts
@@ -2,7 +2,7 @@ import { graphqlServer } from "@hono/graphql-server";
 import { buildSchema } from "drizzle-graphql";
 import { GraphQLObjectType, GraphQLSchema } from "graphql";
 import { Hono } from "hono";
-import { submitGuess } from "../graphql/gameplay/mutations";
+import { requestClue, submitGuess } from "../graphql/gameplay/mutations";
 import {
   getInProgressProgram,
   getProgramProgression,
@@ -42,6 +42,7 @@ const graphQlRouter = new Hono<AppVariables>().use("*", async (c, next) => {
           fields: {
             ...entities.mutations,
             submitGuess,
+            requestClue,
           },
         }),
         types: [

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,5 +1,6 @@
 import type { Context } from "hono";
 import { env } from "hono/adapter";
+import type { Ai } from "worker-configuration.d.ts"; // Explicitly import Ai
 
 // Maximum length for the AI-generated clue to prevent overly verbose responses.
 const MAX_CLUE_LENGTH = 200;
@@ -32,7 +33,7 @@ export async function generateClue(
   currentGuess: string,
   previousClues: string[],
 ): Promise<string | null> {
-  const { AI } = env<{ AI: BaseAiTextGeneration }>(c);
+  const { AI } = env<{ AI: Ai }>(c);
 
   if (!AI) {
     console.error("AI binding not available.");

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -2,19 +2,25 @@ import type { Ai, AiTextGenerationOutput } from "@cloudflare/workers-types";
 import type { Context } from "hono";
 import { env } from "hono/adapter";
 
-// Maximum length for the AI-generated clue to prevent overly verbose responses.
+// Maximum length for the AI-generated clue to prevent
+// overly verbose responses.
 const MAX_CLUE_LENGTH = 200;
 
-// System prompt instructing the AI on its role and constraints for generating clues.
+// System prompt instructing the AI on its role and constraints
+// for generating clues.
 const SYSTEM_PROMPT = `
-You are a helpful assistant for a terminal-based riddle game. Your goal is to provide hints to the player without directly revealing the correct answer.
+You are a helpful assistant for a terminal-based riddle game.
+Your goal is to provide hints to the player without directly
+revealing the correct answer.
 
 Here are the strict rules you must follow:
-1.  NEVER reveal the exact correct answer.
-2.  Provide clues that are short, concise, and helpful for a riddle.
-3.  Consider the current question, the player's last guess, and any previous clues given.
-4.  If the player's guess is very close but incorrect, provide a subtle nudge.
-5.  Keep clues under ${MAX_CLUE_LENGTH} characters.
+1. NEVER reveal the exact correct answer.
+2. Provide clues that are short, concise, and helpful for a riddle.
+3. Consider the current question, the player's last guess, and any
+   previous clues given.
+4. If the player's guess is very close but incorrect, provide a
+   subtle nudge.
+5. Keep clues under ${MAX_CLUE_LENGTH} characters.
 `.trim();
 
 /**
@@ -49,12 +55,11 @@ Player's current incorrect guess: "${currentGuess}"
   if (previousClues.length > 0) {
     userPrompt += `\nPrevious clues given:
 ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}
-`.trim();
+`;
   }
 
   // Add a reminder not to reveal the answer directly.
-  userPrompt +=
-    `\nGenerate a new, short, and subtle clue without revealing "${correctAnswer}".`.trim();
+  userPrompt += `\nGenerate a new, short, and subtle clue without revealing "${correctAnswer}".`;
 
   try {
     const response = (await AI.run("@cf/mistral/mistral-7-b-instruct-v0.1", {
@@ -77,13 +82,10 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}
 
     // Basic check to ensure the AI didn't directly reveal the answer.
     // This is a safeguard, as the system prompt should ideally prevent it.
-    if (
-      clueText.toLowerCase().includes(correctAnswer.toLowerCase()) &&
-      // Only filter if the clue is *just* the answer or too similar.
-      clueText.toLowerCase().length < correctAnswer.toLowerCase().length + 10
-    ) {
-      console.warn("AI generated a clue too close to the answer. Filtering.");
-      return "The AI generated a clue too close to the answer. Try again or check previous clues.";
+    const answerRegex = new RegExp(`\\b${correctAnswer}\\b`, "i");
+    if (answerRegex.test(clueText)) {
+      console.warn("AI generated a clue containing the answer. Filtering.");
+      return null;
     }
 
     // Trim to maximum length to prevent overly long clues.

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,3 +1,4 @@
+import type { Ai, AiTextGenerationOutput } from "@cloudflare/workers-types";
 import type { Context } from "hono";
 import { env } from "hono/adapter";
 

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,0 +1,93 @@
+import { env } from "hono/adapter";
+import { type Context } from "hono";
+
+// Maximum length for the AI-generated clue to prevent overly verbose responses.
+const MAX_CLUE_LENGTH = 200;
+
+// System prompt instructing the AI on its role and constraints for generating clues.
+const SYSTEM_PROMPT = `
+You are a helpful assistant for a terminal-based riddle game. Your goal is to provide hints to the player without directly revealing the correct answer.
+
+Here are the strict rules you must follow:
+1.  NEVER reveal the exact correct answer.
+2.  Provide clues that are short, concise, and helpful for a riddle.
+3.  Consider the current question, the player's last guess, and any previous clues given.
+4.  If the player's guess is very close but incorrect, provide a subtle nudge.
+5.  Keep clues under ${MAX_CLUE_LENGTH} characters.
+`.trim();
+
+/**
+ * Generates a clue using Cloudflare Workers AI.
+ * @param c Hono Context to access the AI binding.
+ * @param gateQuestion The question of the gate.
+ * @param correctAnswer The correct answer to the gate (for AI context, not for revelation).
+ * @param currentGuess The player's current (incorrect) guess.
+ * @param previousClues An array of clues previously given for this gate in the current session.
+ * @returns A generated clue string or null if the AI service fails or no clue is generated.
+ */
+export async function generateClue(
+  c: Context,
+  gateQuestion: string,
+  correctAnswer: string,
+  currentGuess: string,
+  previousClues: string[],
+): Promise<string | null> {
+  const { AI } = env<{ AI: AiTextGeneration }>(c);
+
+  if (!AI) {
+    console.error("AI binding not available.");
+    return null;
+  }
+
+  // Construct the user prompt with all relevant context.
+  let userPrompt = `
+Gate Question: "${gateQuestion}"
+Player's current incorrect guess: "${currentGuess}"
+`.trim();
+
+  if (previousClues.length > 0) {
+    userPrompt += `\nPrevious clues given:
+${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}
+`.trim();
+  }
+
+  // Add a reminder not to reveal the answer directly.
+  userPrompt += `\nGenerate a new, short, and subtle clue without revealing "${correctAnswer}".`.trim();
+
+  try {
+    const response = await AI.run("@cf/mistral/mistral-7-b-instruct-v0.1", {
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: userPrompt },
+      ],
+      // Ensure the AI doesn't get too creative and sticks to the point.
+      temperature: 0.7,
+      max_tokens: 100, // Limit AI response to encourage conciseness
+    });
+
+    // Extract the AI's response content.
+    const clueText = response.response?.trim();
+
+    if (!clueText) {
+      console.warn("AI returned an empty response for clue generation.");
+      return null;
+    }
+
+    // Basic check to ensure the AI didn't directly reveal the answer.
+    // This is a safeguard, as the system prompt should ideally prevent it.
+    if (
+      clueText.toLowerCase().includes(correctAnswer.toLowerCase()) &&
+      // Only filter if the clue is *just* the answer or too similar.
+      clueText.toLowerCase().length < correctAnswer.toLowerCase().length + 10
+    ) {
+      console.warn("AI generated a clue too close to the answer. Filtering.");
+      return "The AI generated a clue too close to the answer. Try again or check previous clues.";
+    }
+
+    // Trim to maximum length to prevent overly long clues.
+    return clueText.substring(0, MAX_CLUE_LENGTH);
+  } catch (error) {
+    console.error("Error generating clue with AI service:", error);
+    return null; // Return null on error to indicate failure to generate a clue.
+  }
+}

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,5 +1,5 @@
+import type { Context } from "hono";
 import { env } from "hono/adapter";
-import { type Context } from "hono";
 
 // Maximum length for the AI-generated clue to prevent overly verbose responses.
 const MAX_CLUE_LENGTH = 200;
@@ -52,7 +52,8 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}
   }
 
   // Add a reminder not to reveal the answer directly.
-  userPrompt += `\nGenerate a new, short, and subtle clue without revealing "${correctAnswer}".`.trim();
+  userPrompt +=
+    `\nGenerate a new, short, and subtle clue without revealing "${correctAnswer}".`.trim();
 
   try {
     const response = await AI.run("@cf/mistral/mistral-7-b-instruct-v0.1", {

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -32,7 +32,7 @@ export async function generateClue(
   currentGuess: string,
   previousClues: string[],
 ): Promise<string | null> {
-  const { AI } = env<{ AI: AiTextGeneration }>(c);
+  const { AI } = env<{ AI: BaseAiTextGeneration }>(c);
 
   if (!AI) {
     console.error("AI binding not available.");

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,6 +1,5 @@
 import type { Context } from "hono";
 import { env } from "hono/adapter";
-import type { Ai } from "worker-configuration.d.ts"; // Explicitly import Ai
 
 // Maximum length for the AI-generated clue to prevent overly verbose responses.
 const MAX_CLUE_LENGTH = 200;
@@ -57,7 +56,7 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}
     `\nGenerate a new, short, and subtle clue without revealing "${correctAnswer}".`.trim();
 
   try {
-    const response = await AI.run("@cf/mistral/mistral-7-b-instruct-v0.1", {
+    const response = (await AI.run("@cf/mistral/mistral-7-b-instruct-v0.1", {
       messages: [
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: userPrompt },
@@ -65,7 +64,7 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}
       // Ensure the AI doesn't get too creative and sticks to the point.
       temperature: 0.7,
       max_tokens: 100, // Limit AI response to encourage conciseness
-    });
+    })) as AiTextGenerationOutput;
 
     // Extract the AI's response content.
     const clueText = response.response?.trim();


### PR DESCRIPTION
- **✨ feat(aiService): add AI clue generation service**
- **🎨 style(aiService.ts): reorder imports and format prompt string**
- **🐛 fix(aiService): correct AI binding type to BaseAiTextGeneration**
- **♻️ refactor(aiService): update AI binding type to Ai and import type**
- **:recycle: refactor: Fix AI response type and remove unused import**
- **✨ feat(graphql): add requestClue mutation and clue eligibility logic**
- **🐛 fix(gameplay/mutations): reverse clues array for correct order**
- **:sparkles: feat: Update workers-types to 4.20260626.1**

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Players can now request a clue after an incorrect guess, with clear limits and remaining-clue counts.
  * Guess responses now indicate whether a clue can still be requested.
* **Bug Fixes**
  * Improved clue availability checks to better handle guidance settings, attempt progress, and per-gate clue caps.
  * Correct guesses now properly reset attempt progress, keeping gameplay state in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->