### PR TITLE
:bug: fix: harden graphql endpoint

### DIFF
--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -39,7 +39,7 @@ export const submitGuess = {
   ) => {
     const MAX_GUESS_LENGTH = 500;
     if (args.guess.length > MAX_GUESS_LENGTH) {
-      throw new Error("Invalid guess length.");
+      throw new Error("Invalid current guess length.");
     }
 
     const db = context.get("db");

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -37,6 +37,11 @@ export const submitGuess = {
     args: { programId: string; gateId: string; guess: string },
     context: AppGraphQLContext,
   ) => {
+    const MAX_GUESS_LENGTH = 500;
+    if (args.guess.length > MAX_GUESS_LENGTH) {
+      throw new Error("Invalid guess length.");
+    }
+
     const db = context.get("db");
     const sessionId = context.get("sessionId");
 

--- a/src/worker/routes/graphql.ts
+++ b/src/worker/routes/graphql.ts
@@ -1,6 +1,10 @@
 import { graphqlServer } from "@hono/graphql-server";
 import { buildSchema } from "drizzle-graphql";
-import { GraphQLObjectType, GraphQLSchema } from "graphql";
+import {
+  GraphQLObjectType,
+  GraphQLSchema,
+  NoSchemaIntrospectionCustomRule,
+} from "graphql";
 import { Hono } from "hono";
 import {
   requestClue,
@@ -36,7 +40,6 @@ const graphQlRouter = new Hono<AppVariables>().use("*", async (c, next) => {
         query: new GraphQLObjectType({
           name: "Query",
           fields: {
-            ...entities.queries,
             getProgramProgression,
             getInProgressProgram,
           },
@@ -44,7 +47,6 @@ const graphQlRouter = new Hono<AppVariables>().use("*", async (c, next) => {
         mutation: new GraphQLObjectType({
           name: "Mutation",
           fields: {
-            ...entities.mutations,
             submitGuess,
             requestClue,
             resetSession,
@@ -72,6 +74,7 @@ const graphQlRouter = new Hono<AppVariables>().use("*", async (c, next) => {
   return graphqlServer({
     schema: cachedSchema,
     graphiql: !isProduction,
+    validationRules: isProduction ? [NoSchemaIntrospectionCustomRule] : [],
   })(c, next);
 });
 

--- a/src/worker/services/aiService.spec.ts
+++ b/src/worker/services/aiService.spec.ts
@@ -118,12 +118,12 @@ describe("aiService", () => {
     expect(aiRunMock).toHaveBeenCalledTimes(2);
     const firstCallArgs = aiRunMock.mock.calls[0][1];
     expect(firstCallArgs.messages[1].content).toContain(
-      "Previous clues given:",
+      "Previous clues already given",
     );
 
     const secondCallArgs = aiRunMock.mock.calls[1][1];
     expect(secondCallArgs.messages[1].content).not.toContain(
-      "Previous clues given:",
+      "Previous clues already given",
     );
   });
 });

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -87,8 +87,8 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
     // Basic check to ensure the AI didn't directly reveal the answer.
     // This is a safeguard, as the system prompt should ideally prevent it.
     const escapedAnswer = escapeRegExp(correctAnswer);
-    const startBoundary = /^\\w/.test(correctAnswer) ? "\\\\b" : "";
-    const endBoundary = /\\w$/.test(correctAnswer) ? "\\\\b" : "";
+    const startBoundary = /^\w/.test(correctAnswer) ? "\\b" : "";
+    const endBoundary = /\w$/.test(correctAnswer) ? "\\b" : "";
     const answerRegex = new RegExp(
       `${startBoundary}${escapedAnswer}${endBoundary}`,
       "i",

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -49,11 +49,11 @@ export async function generateClue(
     return null;
   }
 
-const safeGuess = currentGuess.replace(/"/g, '\\\"');
-let userPrompt = `\nGate Question: \"
-${gateQuestion}\"\nCorrect Answer (never reveal): \"
-${correctAnswer}\"\nPlayer's current incorrect guess: \"
-${safeGuess}\"\nClue attempt: 
+  const safeGuess = currentGuess.replace(/"/g, '\\"');
+  let userPrompt = `\nGate Question: "
+${gateQuestion}"\nCorrect Answer (never reveal): "
+${correctAnswer}"\nPlayer's current incorrect guess: "
+${safeGuess}"\nClue attempt: 
 ${previousClues.length + 1} of 
 ${MAX_CLUES_PER_GATE}\n`.trim();
 
@@ -86,7 +86,13 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
 
     // Basic check to ensure the AI didn't directly reveal the answer.
     // This is a safeguard, as the system prompt should ideally prevent it.
-    const answerRegex = new RegExp(`\\b${escapeRegExp(correctAnswer)}\\b`, "i");
+    const escapedAnswer = escapeRegExp(correctAnswer);
+    const startBoundary = /^\\w/.test(correctAnswer) ? "\\\\b" : "";
+    const endBoundary = /\\w$/.test(correctAnswer) ? "\\\\b" : "";
+    const answerRegex = new RegExp(
+      `${startBoundary}${escapedAnswer}${endBoundary}`,
+      "i",
+    );
     if (answerRegex.test(clueText)) {
       console.warn("AI generated a clue containing the answer. Filtering.");
       return null;

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -49,13 +49,13 @@ export async function generateClue(
     return null;
   }
 
-  // Construct the user prompt with all relevant context.
-  let userPrompt = `
-Gate Question: "${gateQuestion}"
-Correct Answer (never reveal): "${correctAnswer}"
-Player's current incorrect guess: "${currentGuess}"
-Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}
-`.trim();
+const safeGuess = currentGuess.replace(/"/g, '\\\"');
+let userPrompt = `\nGate Question: \"
+${gateQuestion}\"\nCorrect Answer (never reveal): \"
+${correctAnswer}\"\nPlayer's current incorrect guess: \"
+${safeGuess}\"\nClue attempt: 
+${previousClues.length + 1} of 
+${MAX_CLUES_PER_GATE}\n`.trim();
 
   if (previousClues.length > 0) {
     userPrompt += `\nPrevious clues already given (do not repeat these):

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -50,12 +50,10 @@ export async function generateClue(
   }
 
   const safeGuess = currentGuess.replace(/"/g, '\\"');
-  let userPrompt = `\nGate Question: "
-${gateQuestion}"\nCorrect Answer (never reveal): "
-${correctAnswer}"\nPlayer's current incorrect guess: "
-${safeGuess}"\nClue attempt: 
-${previousClues.length + 1} of 
-${MAX_CLUES_PER_GATE}\n`.trim();
+  let userPrompt = `Gate Question: "${gateQuestion}"
+Correct Answer (never reveal): "${correctAnswer}"
+Player's current incorrect guess: "${safeGuess}"
+Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}`.trim();
 
   if (previousClues.length > 0) {
     userPrompt += `\nPrevious clues already given (do not repeat these):

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,4 +1,5 @@
 import type { Ai, AiTextGenerationOutput } from "@cloudflare/workers-types";
+import { MAX_CLUES_PER_GATE } from "@shared/types";
 import type { Context } from "hono";
 import { env } from "hono/adapter";
 
@@ -6,21 +7,23 @@ import { env } from "hono/adapter";
 // overly verbose responses.
 const MAX_CLUE_LENGTH = 200;
 
+const escapeRegExp = (str: string) =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 // System prompt instructing the AI on its role and constraints
 // for generating clues.
 const SYSTEM_PROMPT = `
-You are a helpful assistant for a terminal-based riddle game.
-Your goal is to provide hints to the player without directly
-revealing the correct answer.
+You are a helpful hint-giver for a text-based riddle game.
 
-Here are the strict rules you must follow:
-1. NEVER reveal the exact correct answer.
-2. Provide clues that are short, concise, and helpful for a riddle.
-3. Consider the current question, the player's last guess, and any
-   previous clues given.
-4. If the player's guess is very close but incorrect, provide a
-   subtle nudge.
-5. Keep clues under ${MAX_CLUE_LENGTH} characters.
+Rules:
+1. NEVER state, spell out, or directly paraphrase the correct answer.
+2. Do not reveal answer length, first/last letter, or rhymes unless explicitly asked to nudge that way.
+3. Each clue must add NEW information not present in previous clues — no repeating prior phrasing.
+4. Match clue style to the answer type (e.g. a date gets a time-period hint, a name gets a role/context hint, a phrase gets a meaning hint) — infer this from the gate question and answer.
+5. If the guess is semantically close (synonym, right category, partial match), acknowledge it's "on the right track" before nudging further.
+6. If the guess is far off, redirect toward the correct concept rather than critiquing the wrong guess.
+7. Output ONLY the clue text — no preamble, no labels, no quotes around it.
+8. Keep clues under ${MAX_CLUE_LENGTH} characters.
 `.trim();
 
 /**
@@ -49,17 +52,18 @@ export async function generateClue(
   // Construct the user prompt with all relevant context.
   let userPrompt = `
 Gate Question: "${gateQuestion}"
+Correct Answer (never reveal): "${correctAnswer}"
 Player's current incorrect guess: "${currentGuess}"
+Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}
 `.trim();
 
   if (previousClues.length > 0) {
-    userPrompt += `\nPrevious clues given:
-${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}
-`;
+    userPrompt += `\nPrevious clues already given (do not repeat these):
+${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
   }
 
   // Add a reminder not to reveal the answer directly.
-  userPrompt += `\nGenerate a new, short, and subtle clue without revealing "${correctAnswer}".`;
+  userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
 
   try {
     const response = (await AI.run("@cf/meta/llama-4-scout-17b-16e-instruct", {
@@ -82,7 +86,7 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}
 
     // Basic check to ensure the AI didn't directly reveal the answer.
     // This is a safeguard, as the system prompt should ideally prevent it.
-    const answerRegex = new RegExp(`\\b${correctAnswer}\\b`, "i");
+    const answerRegex = new RegExp(`\\b${escapeRegExp(correctAnswer)}\\b`, "i");
     if (answerRegex.test(clueText)) {
       console.warn("AI generated a clue containing the answer. Filtering.");
       return null;

--- a/src/worker/utils/errorHandler.spec.ts
+++ b/src/worker/utils/errorHandler.spec.ts
@@ -43,12 +43,6 @@ describe("errorHandler", () => {
   });
 
   describe("formatErrorResponse", () => {
-    it("formats response for GraphQL paths", () => {
-      const error = new Error("GraphQL went wrong");
-      const response = formatErrorResponse(error, "/api/graphql");
-
-      expect(response).toEqual({
-  describe("formatErrorResponse", () => {
     let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
@@ -69,27 +63,23 @@ describe("errorHandler", () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(error);
     });
   });
-      });
+  it("provides a default message for GraphQL paths if error has no message", () => {
+    const error = new Error();
+    const response = formatErrorResponse(error, "/api/graphql");
+
+    expect(response).toEqual({
+      errors: [{ message: "Internal Server Error" }],
     });
+  });
 
-    it("provides a default message for GraphQL paths if error has no message", () => {
-      const error = new Error();
-      const response = formatErrorResponse(error, "/api/graphql");
+  it("formats response for non-GraphQL paths", () => {
+    const error = new Error("REST API error");
+    const response = formatErrorResponse(error, "/api/users");
 
-      expect(response).toEqual({
-        errors: [{ message: "Internal Server Error" }],
-      });
-    });
-
-    it("formats response for non-GraphQL paths", () => {
-      const error = new Error("REST API error");
-      const response = formatErrorResponse(error, "/api/users");
-
-      expect(response).toEqual({
-        status: "error",
-        message: "Server Error",
-        code: "INTERNAL_SERVER_ERROR",
-      });
+    expect(response).toEqual({
+      status: "error",
+      message: "Server Error",
+      code: "INTERNAL_SERVER_ERROR",
     });
   });
 });

--- a/src/worker/utils/errorHandler.spec.ts
+++ b/src/worker/utils/errorHandler.spec.ts
@@ -62,24 +62,24 @@ describe("errorHandler", () => {
       });
       expect(consoleErrorSpy).toHaveBeenCalledWith(error);
     });
-  });
-  it("provides a default message for GraphQL paths if error has no message", () => {
-    const error = new Error();
-    const response = formatErrorResponse(error, "/api/graphql");
+    it("provides a default message for GraphQL paths if error has no message", () => {
+      const error = new Error();
+      const response = formatErrorResponse(error, "/api/graphql");
 
-    expect(response).toEqual({
-      errors: [{ message: "Internal Server Error" }],
+      expect(response).toEqual({
+        errors: [{ message: "Internal Server Error" }],
+      });
     });
-  });
 
-  it("formats response for non-GraphQL paths", () => {
-    const error = new Error("REST API error");
-    const response = formatErrorResponse(error, "/api/users");
+    it("formats response for non-GraphQL paths", () => {
+      const error = new Error("REST API error");
+      const response = formatErrorResponse(error, "/api/users");
 
-    expect(response).toEqual({
-      status: "error",
-      message: "Server Error",
-      code: "INTERNAL_SERVER_ERROR",
+      expect(response).toEqual({
+        status: "error",
+        message: "Server Error",
+        code: "INTERNAL_SERVER_ERROR",
+      });
     });
   });
 });

--- a/src/worker/utils/errorHandler.spec.ts
+++ b/src/worker/utils/errorHandler.spec.ts
@@ -48,7 +48,27 @@ describe("errorHandler", () => {
       const response = formatErrorResponse(error, "/api/graphql");
 
       expect(response).toEqual({
+  describe("formatErrorResponse", () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("formats response for GraphQL paths", () => {
+      const error = new Error("GraphQL went wrong");
+      const response = formatErrorResponse(error, "/api/graphql");
+
+      expect(response).toEqual({
         errors: [{ message: "Internal Server Error" }],
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    });
+  });
       });
     });
 

--- a/src/worker/utils/errorHandler.spec.ts
+++ b/src/worker/utils/errorHandler.spec.ts
@@ -48,7 +48,7 @@ describe("errorHandler", () => {
       const response = formatErrorResponse(error, "/api/graphql");
 
       expect(response).toEqual({
-        errors: [{ message: "GraphQL went wrong" }],
+        errors: [{ message: "Internal Server Error" }],
       });
     });
 

--- a/src/worker/utils/errorHandler.ts
+++ b/src/worker/utils/errorHandler.ts
@@ -14,8 +14,9 @@ export const logError = (err: Error, method: string, path: string) => {
 
 export const formatErrorResponse = (err: Error, path: string) => {
   if (path.startsWith("/api/graphql")) {
+    console.error(err);
     return {
-      errors: [{ message: err.message || "Internal Server Error" }],
+      errors: [{ message: "Internal Server Error" }],
     };
   }
   return {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,7 +11,7 @@
   "observability": {
     "enabled": true
   },
-  "upload_source_maps": true,
+  "upload_source_maps": false,
   "assets": {
     "directory": "./dist/client",
     "not_found_handling": "single-page-application"


### PR DESCRIPTION
- **🔧 chore(wrangler): disable source map upload**
- **🐛 fix(error-handler): hide GraphQL error details and log error**
- **✨ feat(ai-service): add clue attempt tracking and regex safety**
- **✨ feat(graphql): add guess length limit and prod introspection guard**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to reject guesses longer than 500 characters.
  - Improved clue generation to avoid repeating previous clues and revealing answers.

- **Security**
  - Disabled GraphQL schema introspection in production.
  - Replaced detailed GraphQL error responses with a generic message.
  - Disabled source map uploads during deployment.

- **Bug Fixes**
  - Improved answer filtering when generated clues contain answer text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->