### PR TITLE
:bug: fix: resolve getPrograms endpoint

### DIFF
--- a/src/react-app/api/queries/useProgramsQuery.spec.ts
+++ b/src/react-app/api/queries/useProgramsQuery.spec.ts
@@ -36,6 +36,8 @@ describe("useProgramsQuery", () => {
     const { result } = renderHook(() => useProgramsQuery(), { wrapper });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(result.current.error?.message).toBe("Failed to fetch programs: 500");
+    expect(result.current.error?.message).toBe(
+      "GraphQL request failed with HTTP 500.",
+    );
   });
 });

--- a/src/react-app/api/queries/useProgramsQuery.ts
+++ b/src/react-app/api/queries/useProgramsQuery.ts
@@ -3,17 +3,11 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { PROGRAM_KEYS } from "../queryKeys";
 
 const GET_PROGRAMS_QUERY = `
-  query GetPrograms($direction: OrderDirection!, $priority: Int!, $limit: Int) {
+  query GetPrograms {
     programs {
       id
       name
       isSelected
-      gates(
-        orderBy: { sequenceOrder: { direction: $direction, priority: $priority } }
-        limit: $limit
-      ) {
-        id
-      }
     }
   }
 `;
@@ -26,11 +20,6 @@ const fetchPrograms = async (): Promise<Program[]> => {
     },
     body: JSON.stringify({
       query: GET_PROGRAMS_QUERY,
-      variables: {
-        direction: "asc",
-        priority: 0,
-        limit: 1,
-      },
     }),
   });
 

--- a/src/react-app/api/queries/useProgramsQuery.ts
+++ b/src/react-app/api/queries/useProgramsQuery.ts
@@ -1,5 +1,6 @@
 import type { Program } from "@shared/types";
 import { queryOptions, useQuery } from "@tanstack/react-query";
+import { graphqlFetch } from "../graphQlClient";
 import { PROGRAM_KEYS } from "../queryKeys";
 
 const GET_PROGRAMS_QUERY = `
@@ -13,27 +14,8 @@ const GET_PROGRAMS_QUERY = `
 `;
 
 const fetchPrograms = async (): Promise<Program[]> => {
-  const rsp = await fetch("/api/graphql", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      query: GET_PROGRAMS_QUERY,
-    }),
-  });
-
-  if (!rsp.ok) {
-    throw new Error(`Failed to fetch programs: ${rsp.status}`);
-  }
-
-  const result = await rsp.json();
-
-  if (result.errors) {
-    throw new Error(`GraphQL Error: ${result.errors[0].message}`);
-  }
-
-  return result.data.programs;
+  const data = await graphqlFetch<{ programs: Program[] }>(GET_PROGRAMS_QUERY);
+  return data.programs;
 };
 
 export const programsQueryOptions = queryOptions({

--- a/src/react-app/components/ProgramSelector.module.css
+++ b/src/react-app/components/ProgramSelector.module.css
@@ -30,6 +30,11 @@
   width: 100%;
 }
 
+select:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+
 .select option {
   background-color: var(--black);
 }

--- a/src/react-app/components/TerminalConfirmModal.module.css
+++ b/src/react-app/components/TerminalConfirmModal.module.css
@@ -29,9 +29,7 @@
   color: var(--green);
   border: 1px solid var(--green);
   cursor: pointer;
-  transition:
-    background-color 0.2s,
-    color 0.2s;
+  transition: font-weight 0.3s;
 }
 
 .cancelButton {
@@ -44,9 +42,17 @@
   width: auto;
 }
 
+.cancelButton:hover {
+  font-weight: bold;
+}
+
+.cancelButton:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+
 .actionButton:hover {
-  background-color: var(--green);
-  color: var(--black);
+  font-weight: bold;
 }
 
 .actionButton:focus-visible {

--- a/src/react-app/index.css
+++ b/src/react-app/index.css
@@ -38,6 +38,15 @@ button {
   font-family: inherit;
 }
 
+button:hover {
+  font-weight: bold;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+
 #app-root {
   max-width: 800px;
   margin: auto;

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { requestClue, submitGuess } from "./mutations";
-import type { AppGraphQLContext } from "./queries";
 
 vi.mock("../../utils/isGuessCloseEnough", () => ({
   default: vi.fn(),
@@ -12,6 +11,7 @@ vi.mock("../../services/aiService", () => ({
 
 import { generateClue } from "../../services/aiService";
 import isGuessCloseEnough from "../../utils/isGuessCloseEnough";
+import type { AppGraphQLContext } from "./types";
 
 type MockDb = {
   query: {

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -8,8 +8,11 @@ import {
   computeCluesRemaining,
   MAX_CLUES_PER_GATE,
 } from "./clueEligibility";
-import type { AppGraphQLContext } from "./queries";
-import { RequestClueResultType, SubmitGuessPayloadType } from "./types";
+import {
+  type AppGraphQLContext,
+  RequestClueResultType,
+  SubmitGuessPayloadType,
+} from "./types";
 
 async function getExistingCluesForGate(
   db: AppGraphQLContext["var"]["db"],

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -46,7 +46,7 @@ export const submitGuess = {
       args.guess.trim().length === 0 ||
       args.guess.length > MAX_GUESS_LENGTH
     ) {
-      throw new Error("Invalid current guess length.");
+      throw new Error("Invalid guess length.");
     }
 
     const db = context.get("db");

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -14,6 +14,8 @@ import {
   SubmitGuessPayloadType,
 } from "./types";
 
+const MAX_GUESS_LENGTH = 500;
+
 async function getExistingCluesForGate(
   db: AppGraphQLContext["var"]["db"],
   sessionProgressId: string,
@@ -40,8 +42,10 @@ export const submitGuess = {
     args: { programId: string; gateId: string; guess: string },
     context: AppGraphQLContext,
   ) => {
-    const MAX_GUESS_LENGTH = 500;
-    if (args.guess.length > MAX_GUESS_LENGTH) {
+    if (
+      args.guess.trim().length === 0 ||
+      args.guess.length > MAX_GUESS_LENGTH
+    ) {
       throw new Error("Invalid current guess length.");
     }
 
@@ -179,12 +183,8 @@ export const requestClue = {
     const db = context.get("db");
     const sessionId = context.get("sessionId");
 
-    const MAX_CURRENT_GUESS_LENGTH = 500;
     const currentGuess = args.currentGuess.trim();
-    if (
-      currentGuess.length === 0 ||
-      currentGuess.length > MAX_CURRENT_GUESS_LENGTH
-    ) {
+    if (currentGuess.length === 0 || currentGuess.length > MAX_GUESS_LENGTH) {
       throw new Error("Invalid current guess length.");
     }
 

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -39,7 +39,7 @@ export const submitGuess = {
   ) => {
     const MAX_GUESS_LENGTH = 500;
     if (args.guess.length > MAX_GUESS_LENGTH) {
-      throw new Error("Invalid guess length.");
+      throw new Error("Invalid current guess length.");
     }
 
     const db = context.get("db");

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -39,7 +39,7 @@ export const submitGuess = {
   ) => {
     const MAX_GUESS_LENGTH = 500;
     if (args.guess.length > MAX_GUESS_LENGTH) {
-      throw new Error("Invalid current guess length.");
+      throw new Error("Invalid guess length.");
     }
 
     const db = context.get("db");

--- a/src/worker/graphql/gameplay/queries.spec.ts
+++ b/src/worker/graphql/gameplay/queries.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { type AppGraphQLContext, getProgramProgression } from "./queries";
+import { getProgramProgression } from "./queries";
+import type { AppGraphQLContext } from "./types";
 
 describe("Gameplay Queries: getProgramProgression", () => {
   let mockDb: unknown;

--- a/src/worker/graphql/gameplay/queries.ts
+++ b/src/worker/graphql/gameplay/queries.ts
@@ -1,11 +1,11 @@
 import { gates, sessionProgress } from "@shared/schema";
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
-import { GraphQLNonNull, GraphQLString } from "graphql";
-import type { Context } from "hono";
-import type { AppVariables } from "../../middleware/db";
-import { ProgressionPayloadType } from "./types";
-
-export type AppGraphQLContext = Context<AppVariables>;
+import { GraphQLList, GraphQLNonNull, GraphQLString } from "graphql";
+import {
+  type AppGraphQLContext,
+  ProgramListItemType,
+  ProgressionPayloadType,
+} from "./types";
 
 export const getProgramProgression = {
   type: ProgressionPayloadType,
@@ -125,5 +125,15 @@ export const getInProgressProgram = {
     });
 
     return progress?.programId ?? null;
+  },
+};
+
+export const getPrograms = {
+  type: new GraphQLNonNull(
+    new GraphQLList(new GraphQLNonNull(ProgramListItemType)),
+  ),
+  resolve: async (_: unknown, __: unknown, context: AppGraphQLContext) => {
+    const db = context.get("db");
+    return db.query.programs.findMany();
   },
 };

--- a/src/worker/graphql/gameplay/queries.ts
+++ b/src/worker/graphql/gameplay/queries.ts
@@ -133,6 +133,9 @@ export const getPrograms = {
     new GraphQLList(new GraphQLNonNull(ProgramListItemType)),
   ),
   resolve: async (_: unknown, __: unknown, context: AppGraphQLContext) => {
+    const sessionId = context.get("sessionId");
+    if (!sessionId) throw new Error("Unauthorized: Missing Session ID");
+
     const db = context.get("db");
     return db.query.programs.findMany();
   },

--- a/src/worker/graphql/gameplay/queries.ts
+++ b/src/worker/graphql/gameplay/queries.ts
@@ -137,6 +137,12 @@ export const getPrograms = {
     if (!sessionId) throw new Error("Unauthorized: Missing Session ID");
 
     const db = context.get("db");
-    return db.query.programs.findMany();
+    return db.query.programs.findMany({
+      columns: {
+        id: true,
+        name: true,
+        isSelected: true,
+      },
+    });
   },
 };

--- a/src/worker/graphql/gameplay/types.ts
+++ b/src/worker/graphql/gameplay/types.ts
@@ -6,6 +6,19 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql";
+import type { Context } from "hono";
+import type { AppVariables } from "../../middleware/db";
+
+export type AppGraphQLContext = Context<AppVariables>;
+
+export const ProgramListItemType = new GraphQLObjectType({
+  name: "ProgramListItem",
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    isSelected: { type: new GraphQLNonNull(GraphQLBoolean) },
+  },
+});
 
 const ActiveGateType = new GraphQLObjectType({
   name: "ActiveGate",

--- a/src/worker/routes/graphql.ts
+++ b/src/worker/routes/graphql.ts
@@ -14,6 +14,7 @@ import {
 import {
   getInProgressProgram,
   getProgramProgression,
+  getPrograms,
 } from "../graphql/gameplay/queries";
 import type { AppVariables } from "../middleware/db";
 
@@ -40,6 +41,7 @@ const graphQlRouter = new Hono<AppVariables>().use("*", async (c, next) => {
         query: new GraphQLObjectType({
           name: "Query",
           fields: {
+            programs: getPrograms,
             getProgramProgression,
             getInProgressProgram,
           },

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,6 +1,5 @@
 import type { Ai, AiTextGenerationOutput } from "@cloudflare/workers-types";
 import { MAX_CLUES_PER_GATE } from "@shared/types";
-import { MAX_CLUES_PER_GATE } from "@shared/types";
 import type { Context } from "hono";
 import { env } from "hono/adapter";
 
@@ -11,23 +10,9 @@ const MAX_CLUE_LENGTH = 200;
 const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-const escapeRegExp = (str: string) =>
-  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
 // System prompt instructing the AI on its role and constraints
 // for generating clues.
 const SYSTEM_PROMPT = `
-You are a helpful hint-giver for a text-based riddle game.
-
-Rules:
-1. NEVER state, spell out, or directly paraphrase the correct answer.
-2. Do not reveal answer length, first/last letter, or rhymes unless explicitly asked to nudge that way.
-3. Each clue must add NEW information not present in previous clues — no repeating prior phrasing.
-4. Match clue style to the answer type (e.g. a date gets a time-period hint, a name gets a role/context hint, a phrase gets a meaning hint) — infer this from the gate question and answer.
-5. If the guess is semantically close (synonym, right category, partial match), acknowledge it's "on the right track" before nudging further.
-6. If the guess is far off, redirect toward the correct concept rather than critiquing the wrong guess.
-7. Output ONLY the clue text — no preamble, no labels, no quotes around it.
-8. Keep clues under ${MAX_CLUE_LENGTH} characters.
 You are a helpful hint-giver for a text-based riddle game.
 
 Rules:
@@ -64,43 +49,20 @@ export async function generateClue(
     return null;
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-  const safeGuess = currentGuess.replace(/"/g, '\\"');
-  // Construct the user prompt with all relevant context.
-  let userPrompt = `
-Gate Question: "${gateQuestion}"
-Correct Answer (never reveal): "${correctAnswer}"
-Player's current incorrect guess: "${safeGuess}"
-Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}
-`.trim();
-=======
-const safeGuess = currentGuess.replace(/"/g, '\\\"');
-let userPrompt = `\nGate Question: \"
-${gateQuestion}\"\nCorrect Answer (never reveal): \"
-${correctAnswer}\"\nPlayer's current incorrect guess: \"
-${safeGuess}\"\nClue attempt:
-${previousClues.length + 1} of
-=======
   const safeGuess = currentGuess.replace(/"/g, '\\"');
   let userPrompt = `\nGate Question: "
 ${gateQuestion}"\nCorrect Answer (never reveal): "
 ${correctAnswer}"\nPlayer's current incorrect guess: "
-${safeGuess}"\nClue attempt: 
-${previousClues.length + 1} of 
->>>>>>> 3382ff7 (🐛 fix(worker): refine AI regex and error messages)
+${safeGuess}"\nClue attempt:
+${previousClues.length + 1} of
 ${MAX_CLUES_PER_GATE}\n`.trim();
->>>>>>> 3bae02d (:bug: fix: escape user input)
 
   if (previousClues.length > 0) {
-    userPrompt += `\nPrevious clues already given (do not repeat these):
-${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
     userPrompt += `\nPrevious clues already given (do not repeat these):
 ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
   }
 
   // Add a reminder not to reveal the answer directly.
-  userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
   userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
 
   try {
@@ -125,13 +87,8 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
     // Basic check to ensure the AI didn't directly reveal the answer.
     // This is a safeguard, as the system prompt should ideally prevent it.
     const escapedAnswer = escapeRegExp(correctAnswer);
-<<<<<<< HEAD
     const startBoundary = /^\w/.test(correctAnswer) ? "\\b" : "";
     const endBoundary = /\w$/.test(correctAnswer) ? "\\b" : "";
-=======
-    const startBoundary = /^\\w/.test(correctAnswer) ? "\\\\b" : "";
-    const endBoundary = /\\w$/.test(correctAnswer) ? "\\\\b" : "";
->>>>>>> 3382ff7 (🐛 fix(worker): refine AI regex and error messages)
     const answerRegex = new RegExp(
       `${startBoundary}${escapedAnswer}${endBoundary}`,
       "i",

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -63,8 +63,7 @@ export async function generateClue(
     console.error("AI binding not available.");
     return null;
   }
-
-  const safeGuess = currentGuess.replace(/"/g, '\\"');
+  const safeGuess = currentGuess.replace(/"/g, '\\"').replace(/\n/g, " ");
   let userPrompt = `Gate Question: "${gateQuestion}"
 Correct Answer (never reveal): "${correctAnswer}"
 Player's current incorrect guess: "${safeGuess}"

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,11 +1,15 @@
 import type { Ai, AiTextGenerationOutput } from "@cloudflare/workers-types";
 import { MAX_CLUES_PER_GATE } from "@shared/types";
+import { MAX_CLUES_PER_GATE } from "@shared/types";
 import type { Context } from "hono";
 import { env } from "hono/adapter";
 
 // Maximum length for the AI-generated clue to prevent
 // overly verbose responses.
 const MAX_CLUE_LENGTH = 200;
+
+const escapeRegExp = (str: string) =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -60,6 +64,7 @@ export async function generateClue(
     return null;
   }
 
+<<<<<<< HEAD
   const safeGuess = currentGuess.replace(/"/g, '\\"');
   // Construct the user prompt with all relevant context.
   let userPrompt = `
@@ -68,8 +73,19 @@ Correct Answer (never reveal): "${correctAnswer}"
 Player's current incorrect guess: "${safeGuess}"
 Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}
 `.trim();
+=======
+const safeGuess = currentGuess.replace(/"/g, '\\\"');
+let userPrompt = `\nGate Question: \"
+${gateQuestion}\"\nCorrect Answer (never reveal): \"
+${correctAnswer}\"\nPlayer's current incorrect guess: \"
+${safeGuess}\"\nClue attempt:
+${previousClues.length + 1} of
+${MAX_CLUES_PER_GATE}\n`.trim();
+>>>>>>> 3bae02d (:bug: fix: escape user input)
 
   if (previousClues.length > 0) {
+    userPrompt += `\nPrevious clues already given (do not repeat these):
+${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
     userPrompt += `\nPrevious clues already given (do not repeat these):
 ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
   }

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -25,16 +25,6 @@ Rules:
 7. Output ONLY the clue text — no preamble, no labels, no quotes around it.
 8. Keep clues under ${MAX_CLUE_LENGTH} characters.
 You are a helpful hint-giver for a text-based riddle game.
-
-Rules:
-1. NEVER state, spell out, or directly paraphrase the correct answer.
-2. Do not reveal answer length, first/last letter, or rhymes unless explicitly asked to nudge that way.
-3. Each clue must add NEW information not present in previous clues — no repeating prior phrasing.
-4. Match clue style to the answer type (e.g. a date gets a time-period hint, a name gets a role/context hint, a phrase gets a meaning hint) — infer this from the gate question and answer.
-5. If the guess is semantically close (synonym, right category, partial match), acknowledge it's "on the right track" before nudging further.
-6. If the guess is far off, redirect toward the correct concept rather than critiquing the wrong guess.
-7. Output ONLY the clue text — no preamble, no labels, no quotes around it.
-8. Keep clues under ${MAX_CLUE_LENGTH} characters.
 `.trim();
 
 /**
@@ -68,12 +58,9 @@ Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}`.trim();
   if (previousClues.length > 0) {
     userPrompt += `\nPrevious clues already given (do not repeat these):
 ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
-    userPrompt += `\nPrevious clues already given (do not repeat these):
-${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
   }
 
   // Add a reminder not to reveal the answer directly.
-  userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
   userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
 
   try {

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -65,6 +65,7 @@ export async function generateClue(
   }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   const safeGuess = currentGuess.replace(/"/g, '\\"');
   // Construct the user prompt with all relevant context.
   let userPrompt = `
@@ -80,6 +81,14 @@ ${gateQuestion}\"\nCorrect Answer (never reveal): \"
 ${correctAnswer}\"\nPlayer's current incorrect guess: \"
 ${safeGuess}\"\nClue attempt:
 ${previousClues.length + 1} of
+=======
+  const safeGuess = currentGuess.replace(/"/g, '\\"');
+  let userPrompt = `\nGate Question: "
+${gateQuestion}"\nCorrect Answer (never reveal): "
+${correctAnswer}"\nPlayer's current incorrect guess: "
+${safeGuess}"\nClue attempt: 
+${previousClues.length + 1} of 
+>>>>>>> 3382ff7 (🐛 fix(worker): refine AI regex and error messages)
 ${MAX_CLUES_PER_GATE}\n`.trim();
 >>>>>>> 3bae02d (:bug: fix: escape user input)
 
@@ -116,8 +125,13 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
     // Basic check to ensure the AI didn't directly reveal the answer.
     // This is a safeguard, as the system prompt should ideally prevent it.
     const escapedAnswer = escapeRegExp(correctAnswer);
+<<<<<<< HEAD
     const startBoundary = /^\w/.test(correctAnswer) ? "\\b" : "";
     const endBoundary = /\w$/.test(correctAnswer) ? "\\b" : "";
+=======
+    const startBoundary = /^\\w/.test(correctAnswer) ? "\\\\b" : "";
+    const endBoundary = /\\w$/.test(correctAnswer) ? "\\\\b" : "";
+>>>>>>> 3382ff7 (🐛 fix(worker): refine AI regex and error messages)
     const answerRegex = new RegExp(
       `${startBoundary}${escapedAnswer}${endBoundary}`,
       "i",

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,5 +1,6 @@
 import type { Ai, AiTextGenerationOutput } from "@cloudflare/workers-types";
 import { MAX_CLUES_PER_GATE } from "@shared/types";
+import { MAX_CLUES_PER_GATE } from "@shared/types";
 import type { Context } from "hono";
 import { env } from "hono/adapter";
 
@@ -10,9 +11,23 @@ const MAX_CLUE_LENGTH = 200;
 const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+const escapeRegExp = (str: string) =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 // System prompt instructing the AI on its role and constraints
 // for generating clues.
 const SYSTEM_PROMPT = `
+You are a helpful hint-giver for a text-based riddle game.
+
+Rules:
+1. NEVER state, spell out, or directly paraphrase the correct answer.
+2. Do not reveal answer length, first/last letter, or rhymes unless explicitly asked to nudge that way.
+3. Each clue must add NEW information not present in previous clues — no repeating prior phrasing.
+4. Match clue style to the answer type (e.g. a date gets a time-period hint, a name gets a role/context hint, a phrase gets a meaning hint) — infer this from the gate question and answer.
+5. If the guess is semantically close (synonym, right category, partial match), acknowledge it's "on the right track" before nudging further.
+6. If the guess is far off, redirect toward the correct concept rather than critiquing the wrong guess.
+7. Output ONLY the clue text — no preamble, no labels, no quotes around it.
+8. Keep clues under ${MAX_CLUE_LENGTH} characters.
 You are a helpful hint-giver for a text-based riddle game.
 
 Rules:
@@ -50,19 +65,20 @@ export async function generateClue(
   }
 
   const safeGuess = currentGuess.replace(/"/g, '\\"');
-  let userPrompt = `\nGate Question: "
-${gateQuestion}"\nCorrect Answer (never reveal): "
-${correctAnswer}"\nPlayer's current incorrect guess: "
-${safeGuess}"\nClue attempt:
-${previousClues.length + 1} of
-${MAX_CLUES_PER_GATE}\n`.trim();
+  let userPrompt = `Gate Question: "${gateQuestion}"
+Correct Answer (never reveal): "${correctAnswer}"
+Player's current incorrect guess: "${safeGuess}"
+Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}`.trim();
 
   if (previousClues.length > 0) {
+    userPrompt += `\nPrevious clues already given (do not repeat these):
+${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
     userPrompt += `\nPrevious clues already given (do not repeat these):
 ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
   }
 
   // Add a reminder not to reveal the answer directly.
+  userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
   userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
 
   try {

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,15 +1,11 @@
 import type { Ai, AiTextGenerationOutput } from "@cloudflare/workers-types";
 import { MAX_CLUES_PER_GATE } from "@shared/types";
-import { MAX_CLUES_PER_GATE } from "@shared/types";
 import type { Context } from "hono";
 import { env } from "hono/adapter";
 
 // Maximum length for the AI-generated clue to prevent
 // overly verbose responses.
 const MAX_CLUE_LENGTH = 200;
-
-const escapeRegExp = (str: string) =>
-  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/worker/services/aiService.ts
+++ b/src/worker/services/aiService.ts
@@ -1,5 +1,6 @@
 import type { Ai, AiTextGenerationOutput } from "@cloudflare/workers-types";
 import { MAX_CLUES_PER_GATE } from "@shared/types";
+import { MAX_CLUES_PER_GATE } from "@shared/types";
 import type { Context } from "hono";
 import { env } from "hono/adapter";
 
@@ -10,9 +11,23 @@ const MAX_CLUE_LENGTH = 200;
 const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+const escapeRegExp = (str: string) =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 // System prompt instructing the AI on its role and constraints
 // for generating clues.
 const SYSTEM_PROMPT = `
+You are a helpful hint-giver for a text-based riddle game.
+
+Rules:
+1. NEVER state, spell out, or directly paraphrase the correct answer.
+2. Do not reveal answer length, first/last letter, or rhymes unless explicitly asked to nudge that way.
+3. Each clue must add NEW information not present in previous clues — no repeating prior phrasing.
+4. Match clue style to the answer type (e.g. a date gets a time-period hint, a name gets a role/context hint, a phrase gets a meaning hint) — infer this from the gate question and answer.
+5. If the guess is semantically close (synonym, right category, partial match), acknowledge it's "on the right track" before nudging further.
+6. If the guess is far off, redirect toward the correct concept rather than critiquing the wrong guess.
+7. Output ONLY the clue text — no preamble, no labels, no quotes around it.
+8. Keep clues under ${MAX_CLUE_LENGTH} characters.
 You are a helpful hint-giver for a text-based riddle game.
 
 Rules:
@@ -50,10 +65,13 @@ export async function generateClue(
   }
 
   const safeGuess = currentGuess.replace(/"/g, '\\"');
-  let userPrompt = `Gate Question: "${gateQuestion}"
+  // Construct the user prompt with all relevant context.
+  let userPrompt = `
+Gate Question: "${gateQuestion}"
 Correct Answer (never reveal): "${correctAnswer}"
 Player's current incorrect guess: "${safeGuess}"
-Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}`.trim();
+Clue attempt: ${previousClues.length + 1} of ${MAX_CLUES_PER_GATE}
+`.trim();
 
   if (previousClues.length > 0) {
     userPrompt += `\nPrevious clues already given (do not repeat these):
@@ -61,6 +79,7 @@ ${previousClues.map((clue, i) => `${i + 1}. "${clue}"`).join("\n")}`;
   }
 
   // Add a reminder not to reveal the answer directly.
+  userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
   userPrompt += `\nGenerate the next clue, strictly better/more specific than the previous ones, without revealing the answer.`;
 
   try {

--- a/src/worker/utils/errorHandler.spec.ts
+++ b/src/worker/utils/errorHandler.spec.ts
@@ -58,16 +58,6 @@ describe("errorHandler", () => {
       });
       expect(consoleErrorSpy).toHaveBeenCalledWith(error);
     });
-
-    it("formats response for GraphQL paths", () => {
-      const error = new Error("GraphQL went wrong");
-      const response = formatErrorResponse(error, "/api/graphql");
-
-      expect(response).toEqual({
-        errors: [{ message: "Internal Server Error" }],
-      });
-      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
-    });
     it("provides a default message for GraphQL paths if error has no message", () => {
       const error = new Error();
       const response = formatErrorResponse(error, "/api/graphql");

--- a/src/worker/utils/errorHandler.spec.ts
+++ b/src/worker/utils/errorHandler.spec.ts
@@ -49,8 +49,14 @@ describe("errorHandler", () => {
       consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    afterEach(() => {
-      consoleErrorSpy.mockRestore();
+    it("formats response for GraphQL paths", () => {
+      const error = new Error("GraphQL went wrong");
+      const response = formatErrorResponse(error, "/api/graphql");
+
+      expect(response).toEqual({
+        errors: [{ message: "Internal Server Error" }],
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
     });
 
     it("formats response for GraphQL paths", () => {

--- a/src/worker/utils/errorHandler.spec.ts
+++ b/src/worker/utils/errorHandler.spec.ts
@@ -68,24 +68,24 @@ describe("errorHandler", () => {
       });
       expect(consoleErrorSpy).toHaveBeenCalledWith(error);
     });
-  });
-  it("provides a default message for GraphQL paths if error has no message", () => {
-    const error = new Error();
-    const response = formatErrorResponse(error, "/api/graphql");
+    it("provides a default message for GraphQL paths if error has no message", () => {
+      const error = new Error();
+      const response = formatErrorResponse(error, "/api/graphql");
 
-    expect(response).toEqual({
-      errors: [{ message: "Internal Server Error" }],
+      expect(response).toEqual({
+        errors: [{ message: "Internal Server Error" }],
+      });
     });
-  });
 
-  it("formats response for non-GraphQL paths", () => {
-    const error = new Error("REST API error");
-    const response = formatErrorResponse(error, "/api/users");
+    it("formats response for non-GraphQL paths", () => {
+      const error = new Error("REST API error");
+      const response = formatErrorResponse(error, "/api/users");
 
-    expect(response).toEqual({
-      status: "error",
-      message: "Server Error",
-      code: "INTERNAL_SERVER_ERROR",
+      expect(response).toEqual({
+        status: "error",
+        message: "Server Error",
+        code: "INTERNAL_SERVER_ERROR",
+      });
     });
   });
 });

--- a/src/worker/utils/errorHandler.spec.ts
+++ b/src/worker/utils/errorHandler.spec.ts
@@ -68,24 +68,24 @@ describe("errorHandler", () => {
       });
       expect(consoleErrorSpy).toHaveBeenCalledWith(error);
     });
-    it("provides a default message for GraphQL paths if error has no message", () => {
-      const error = new Error();
-      const response = formatErrorResponse(error, "/api/graphql");
+  });
+  it("provides a default message for GraphQL paths if error has no message", () => {
+    const error = new Error();
+    const response = formatErrorResponse(error, "/api/graphql");
 
-      expect(response).toEqual({
-        errors: [{ message: "Internal Server Error" }],
-      });
+    expect(response).toEqual({
+      errors: [{ message: "Internal Server Error" }],
     });
+  });
 
-    it("formats response for non-GraphQL paths", () => {
-      const error = new Error("REST API error");
-      const response = formatErrorResponse(error, "/api/users");
+  it("formats response for non-GraphQL paths", () => {
+    const error = new Error("REST API error");
+    const response = formatErrorResponse(error, "/api/users");
 
-      expect(response).toEqual({
-        status: "error",
-        message: "Server Error",
-        code: "INTERNAL_SERVER_ERROR",
-      });
+    expect(response).toEqual({
+      status: "error",
+      message: "Server Error",
+      code: "INTERNAL_SERVER_ERROR",
     });
   });
 });


### PR DESCRIPTION
- **🔧 chore(wrangler): disable source map upload**
- **🐛 fix(error-handler): hide GraphQL error details and log error**
- **✨ feat(ai-service): add clue attempt tracking and regex safety**
- **✨ feat(graphql): add guess length limit and prod introspection guard**
- **:bug: fix: escape user input**
- **:white_check_mark: test: add console.error spy and assertion for logging behavior**
- **🐛 fix(worker): refine AI regex and error messages**
- **:bug: fix: resulve escape within RegEx**
- **♻️ refactor(ai-service): simplify prompt formatting and tidy tests**
- **♻️ refactor(gameplay): import AppGraphQLContext from types module**
- **✨ feat(graphql-gameplay): add programs query and list type**
- **✨ feat(graphql): add programs query to GraphQL schema**
- **♻️ refactor(programs-query): drop unused GraphQL variables from programs query**

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added program listings with each program’s name, selection status, and identifier.
  * Added a 500-character limit for guesses.
  * Improved AI-generated clues to avoid revealing answers and repeating previous clues.

* **Bug Fixes**
  * GraphQL errors now display a generic message while details are logged securely.
  * Improved handling of answer matching in generated clues.

* **Security**
  * Restricted GraphQL schema introspection in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->