### PR TITLE
:wrench: chore: Drizzle schema cleanup and optimizations

### DIFF
--- a/migrations/0009_whole_quasar.sql
+++ b/migrations/0009_whole_quasar.sql
@@ -1,0 +1,8 @@
+DROP TABLE `game_state`;--> statement-breakpoint
+ALTER TABLE `gates` DROP COLUMN `is_solved`;--> statement-breakpoint
+ALTER TABLE `gates` DROP COLUMN `solved_at`;--> statement-breakpoint
+ALTER TABLE `gates` DROP COLUMN `attempt_count`;--> statement-breakpoint
+ALTER TABLE `gates` DROP COLUMN `guidance_prompt`;--> statement-breakpoint
+ALTER TABLE `programs` DROP COLUMN `is_selected`;--> statement-breakpoint
+ALTER TABLE `programs` DROP COLUMN `selected_at`;--> statement-breakpoint
+ALTER TABLE `programs` DROP COLUMN `completed_at`;

--- a/migrations/0010_funny_santa_claus.sql
+++ b/migrations/0010_funny_santa_claus.sql
@@ -8,6 +8,12 @@ CREATE TABLE `session_completed_gates` (
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX `unique_session_gate_completion` ON `session_completed_gates` (`session_progress_id`,`gate_id`);--> statement-breakpoint
+-- Extract existing completed_gate_ids JSON data into session_completed_gates
+-- before the column is dropped in the table rebuild below.
+INSERT INTO `session_completed_gates` (`session_progress_id`, `gate_id`, `completed_at`)
+  SELECT `sp`.`id`, `je`.`value`, `sp`.`updated_at`
+  FROM `session_progress` `sp`, json_each(`sp`.`completed_gate_ids`) AS `je`
+  WHERE `sp`.`completed_gate_ids` IS NOT NULL;--> statement-breakpoint
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
 CREATE TABLE `__new_session_progress` (
 	`id` text PRIMARY KEY NOT NULL,

--- a/migrations/0010_funny_santa_claus.sql
+++ b/migrations/0010_funny_santa_claus.sql
@@ -1,0 +1,31 @@
+CREATE TABLE `session_completed_gates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_progress_id` text NOT NULL,
+	`gate_id` text NOT NULL,
+	`completed_at` integer NOT NULL,
+	FOREIGN KEY (`session_progress_id`) REFERENCES `session_progress`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`gate_id`) REFERENCES `gates`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `unique_session_gate_completion` ON `session_completed_gates` (`session_progress_id`,`gate_id`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_session_progress` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`program_id` text NOT NULL,
+	`current_gate_id` text,
+	`status` text DEFAULT 'in_progress' NOT NULL,
+	`started_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`completed_at` integer,
+	`attempt_count` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`program_id`) REFERENCES `programs`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`current_gate_id`) REFERENCES `gates`(`id`) ON UPDATE no action ON DELETE set null,
+	CONSTRAINT "session_status_check" CHECK("__new_session_progress"."status" IN ('in_progress', 'completed'))
+);
+--> statement-breakpoint
+INSERT INTO `__new_session_progress`("id", "session_id", "program_id", "current_gate_id", "status", "started_at", "updated_at", "completed_at", "attempt_count") SELECT "id", "session_id", "program_id", "current_gate_id", "status", "started_at", "updated_at", "completed_at", "attempt_count" FROM `session_progress`;--> statement-breakpoint
+DROP TABLE `session_progress`;--> statement-breakpoint
+ALTER TABLE `__new_session_progress` RENAME TO `session_progress`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `unique_session_progress` ON `session_progress` (`session_id`,`program_id`);

--- a/migrations/0011_stiff_riptide.sql
+++ b/migrations/0011_stiff_riptide.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `gates_program_sequence_idx` ON `gates` (`program_id`,`sequence_order`);

--- a/migrations/0012_dusty_madrox.sql
+++ b/migrations/0012_dusty_madrox.sql
@@ -1,0 +1,1 @@
+DROP INDEX `gates_program_sequence_idx`;

--- a/migrations/meta/0009_snapshot.json
+++ b/migrations/meta/0009_snapshot.json
@@ -1,0 +1,358 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ad51cb54-d727-49d3-8d97-103b4520e724",
+  "prevId": "67fe7023-562f-402a-ac05-74bda844075c",
+  "tables": {
+    "gate_clues": {
+      "name": "gate_clues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clue_text": {
+          "name": "clue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count_at_request": {
+          "name": "attempt_count_at_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "gate_clues_session_progress_id_idx": {
+          "name": "gate_clues_session_progress_id_idx",
+          "columns": ["session_progress_id"],
+          "isUnique": false
+        },
+        "gate_clues_gate_id_idx": {
+          "name": "gate_clues_gate_id_idx",
+          "columns": ["gate_id"],
+          "isUnique": false
+        },
+        "unique_clue_per_attempt": {
+          "name": "unique_clue_per_attempt",
+          "columns": [
+            "session_progress_id",
+            "gate_id",
+            "attempt_count_at_request"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gate_clues_session_progress_id_session_progress_id_fk": {
+          "name": "gate_clues_session_progress_id_session_progress_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gate_clues_gate_id_gates_id_fk": {
+          "name": "gate_clues_gate_id_gates_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gates": {
+      "name": "gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success_message": {
+          "name": "success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.875
+        },
+        "guidance_enabled": {
+          "name": "guidance_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guidance_threshold": {
+          "name": "guidance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {
+        "unique_program_sequence": {
+          "name": "unique_program_sequence",
+          "columns": ["program_id", "sequence_order"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gates_program_id_programs_id_fk": {
+          "name": "gates_program_id_programs_id_fk",
+          "tableFrom": "gates",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "programs": {
+      "name": "programs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_progress": {
+      "name": "session_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_gate_id": {
+          "name": "current_gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_gate_ids": {
+          "name": "completed_gate_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_session_progress": {
+          "name": "unique_session_progress",
+          "columns": ["session_id", "program_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_progress_program_id_programs_id_fk": {
+          "name": "session_progress_program_id_programs_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_progress_current_gate_id_gates_id_fk": {
+          "name": "session_progress_current_gate_id_gates_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "gates",
+          "columnsFrom": ["current_gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0010_snapshot.json
+++ b/migrations/meta/0010_snapshot.json
@@ -1,0 +1,418 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8e5566ff-3000-4ccf-a2ec-61adec130fc2",
+  "prevId": "ad51cb54-d727-49d3-8d97-103b4520e724",
+  "tables": {
+    "gate_clues": {
+      "name": "gate_clues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clue_text": {
+          "name": "clue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count_at_request": {
+          "name": "attempt_count_at_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "gate_clues_session_progress_id_idx": {
+          "name": "gate_clues_session_progress_id_idx",
+          "columns": ["session_progress_id"],
+          "isUnique": false
+        },
+        "gate_clues_gate_id_idx": {
+          "name": "gate_clues_gate_id_idx",
+          "columns": ["gate_id"],
+          "isUnique": false
+        },
+        "unique_clue_per_attempt": {
+          "name": "unique_clue_per_attempt",
+          "columns": [
+            "session_progress_id",
+            "gate_id",
+            "attempt_count_at_request"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gate_clues_session_progress_id_session_progress_id_fk": {
+          "name": "gate_clues_session_progress_id_session_progress_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gate_clues_gate_id_gates_id_fk": {
+          "name": "gate_clues_gate_id_gates_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gates": {
+      "name": "gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success_message": {
+          "name": "success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.875
+        },
+        "guidance_enabled": {
+          "name": "guidance_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guidance_threshold": {
+          "name": "guidance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {
+        "unique_program_sequence": {
+          "name": "unique_program_sequence",
+          "columns": ["program_id", "sequence_order"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gates_program_id_programs_id_fk": {
+          "name": "gates_program_id_programs_id_fk",
+          "tableFrom": "gates",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "programs": {
+      "name": "programs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_completed_gates": {
+      "name": "session_completed_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_session_gate_completion": {
+          "name": "unique_session_gate_completion",
+          "columns": ["session_progress_id", "gate_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_completed_gates_session_progress_id_session_progress_id_fk": {
+          "name": "session_completed_gates_session_progress_id_session_progress_id_fk",
+          "tableFrom": "session_completed_gates",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_completed_gates_gate_id_gates_id_fk": {
+          "name": "session_completed_gates_gate_id_gates_id_fk",
+          "tableFrom": "session_completed_gates",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_progress": {
+      "name": "session_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_gate_id": {
+          "name": "current_gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_session_progress": {
+          "name": "unique_session_progress",
+          "columns": ["session_id", "program_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_progress_program_id_programs_id_fk": {
+          "name": "session_progress_program_id_programs_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_progress_current_gate_id_gates_id_fk": {
+          "name": "session_progress_current_gate_id_gates_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "gates",
+          "columnsFrom": ["current_gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_status_check": {
+          "name": "session_status_check",
+          "value": "\"session_progress\".\"status\" IN ('in_progress', 'completed')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0011_snapshot.json
+++ b/migrations/meta/0011_snapshot.json
@@ -1,0 +1,423 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "40376b6b-7fe1-42c5-86a4-51eb7d7cc3ec",
+  "prevId": "8e5566ff-3000-4ccf-a2ec-61adec130fc2",
+  "tables": {
+    "gate_clues": {
+      "name": "gate_clues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clue_text": {
+          "name": "clue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count_at_request": {
+          "name": "attempt_count_at_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "gate_clues_session_progress_id_idx": {
+          "name": "gate_clues_session_progress_id_idx",
+          "columns": ["session_progress_id"],
+          "isUnique": false
+        },
+        "gate_clues_gate_id_idx": {
+          "name": "gate_clues_gate_id_idx",
+          "columns": ["gate_id"],
+          "isUnique": false
+        },
+        "unique_clue_per_attempt": {
+          "name": "unique_clue_per_attempt",
+          "columns": [
+            "session_progress_id",
+            "gate_id",
+            "attempt_count_at_request"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gate_clues_session_progress_id_session_progress_id_fk": {
+          "name": "gate_clues_session_progress_id_session_progress_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gate_clues_gate_id_gates_id_fk": {
+          "name": "gate_clues_gate_id_gates_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gates": {
+      "name": "gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success_message": {
+          "name": "success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.875
+        },
+        "guidance_enabled": {
+          "name": "guidance_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guidance_threshold": {
+          "name": "guidance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {
+        "gates_program_sequence_idx": {
+          "name": "gates_program_sequence_idx",
+          "columns": ["program_id", "sequence_order"],
+          "isUnique": false
+        },
+        "unique_program_sequence": {
+          "name": "unique_program_sequence",
+          "columns": ["program_id", "sequence_order"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gates_program_id_programs_id_fk": {
+          "name": "gates_program_id_programs_id_fk",
+          "tableFrom": "gates",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "programs": {
+      "name": "programs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_completed_gates": {
+      "name": "session_completed_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_session_gate_completion": {
+          "name": "unique_session_gate_completion",
+          "columns": ["session_progress_id", "gate_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_completed_gates_session_progress_id_session_progress_id_fk": {
+          "name": "session_completed_gates_session_progress_id_session_progress_id_fk",
+          "tableFrom": "session_completed_gates",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_completed_gates_gate_id_gates_id_fk": {
+          "name": "session_completed_gates_gate_id_gates_id_fk",
+          "tableFrom": "session_completed_gates",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_progress": {
+      "name": "session_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_gate_id": {
+          "name": "current_gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_session_progress": {
+          "name": "unique_session_progress",
+          "columns": ["session_id", "program_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_progress_program_id_programs_id_fk": {
+          "name": "session_progress_program_id_programs_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_progress_current_gate_id_gates_id_fk": {
+          "name": "session_progress_current_gate_id_gates_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "gates",
+          "columnsFrom": ["current_gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_status_check": {
+          "name": "session_status_check",
+          "value": "\"session_progress\".\"status\" IN ('in_progress', 'completed')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0012_snapshot.json
+++ b/migrations/meta/0012_snapshot.json
@@ -1,0 +1,418 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fc84b3a6-4d97-4586-9a60-163900ff15ca",
+  "prevId": "40376b6b-7fe1-42c5-86a4-51eb7d7cc3ec",
+  "tables": {
+    "gate_clues": {
+      "name": "gate_clues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clue_text": {
+          "name": "clue_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count_at_request": {
+          "name": "attempt_count_at_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "gate_clues_session_progress_id_idx": {
+          "name": "gate_clues_session_progress_id_idx",
+          "columns": ["session_progress_id"],
+          "isUnique": false
+        },
+        "gate_clues_gate_id_idx": {
+          "name": "gate_clues_gate_id_idx",
+          "columns": ["gate_id"],
+          "isUnique": false
+        },
+        "unique_clue_per_attempt": {
+          "name": "unique_clue_per_attempt",
+          "columns": [
+            "session_progress_id",
+            "gate_id",
+            "attempt_count_at_request"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gate_clues_session_progress_id_session_progress_id_fk": {
+          "name": "gate_clues_session_progress_id_session_progress_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gate_clues_gate_id_gates_id_fk": {
+          "name": "gate_clues_gate_id_gates_id_fk",
+          "tableFrom": "gate_clues",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gates": {
+      "name": "gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_answer": {
+          "name": "correct_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success_message": {
+          "name": "success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.875
+        },
+        "guidance_enabled": {
+          "name": "guidance_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "guidance_threshold": {
+          "name": "guidance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {
+        "unique_program_sequence": {
+          "name": "unique_program_sequence",
+          "columns": ["program_id", "sequence_order"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gates_program_id_programs_id_fk": {
+          "name": "gates_program_id_programs_id_fk",
+          "tableFrom": "gates",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "programs": {
+      "name": "programs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_completed_gates": {
+      "name": "session_completed_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_progress_id": {
+          "name": "session_progress_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_session_gate_completion": {
+          "name": "unique_session_gate_completion",
+          "columns": ["session_progress_id", "gate_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_completed_gates_session_progress_id_session_progress_id_fk": {
+          "name": "session_completed_gates_session_progress_id_session_progress_id_fk",
+          "tableFrom": "session_completed_gates",
+          "tableTo": "session_progress",
+          "columnsFrom": ["session_progress_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_completed_gates_gate_id_gates_id_fk": {
+          "name": "session_completed_gates_gate_id_gates_id_fk",
+          "tableFrom": "session_completed_gates",
+          "tableTo": "gates",
+          "columnsFrom": ["gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_progress": {
+      "name": "session_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_gate_id": {
+          "name": "current_gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_session_progress": {
+          "name": "unique_session_progress",
+          "columns": ["session_id", "program_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_progress_program_id_programs_id_fk": {
+          "name": "session_progress_program_id_programs_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "programs",
+          "columnsFrom": ["program_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_progress_current_gate_id_gates_id_fk": {
+          "name": "session_progress_current_gate_id_gates_id_fk",
+          "tableFrom": "session_progress",
+          "tableTo": "gates",
+          "columnsFrom": ["current_gate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_status_check": {
+          "name": "session_status_check",
+          "value": "\"session_progress\".\"status\" IN ('in_progress', 'completed')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1784171790933,
       "tag": "0011_stiff_riptide",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1784173644524,
+      "tag": "0012_dusty_madrox",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1782680482300,
       "tag": "0008_safe_mystique",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1784164222944,
+      "tag": "0009_whole_quasar",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1784168875620,
       "tag": "0010_funny_santa_claus",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1784171790933,
+      "tag": "0011_stiff_riptide",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1784164222944,
       "tag": "0009_whole_quasar",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1784168875620,
+      "tag": "0010_funny_santa_claus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/react-app/api/queries/useProgramsQuery.spec.ts
+++ b/src/react-app/api/queries/useProgramsQuery.spec.ts
@@ -3,9 +3,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createQueryWrapper } from "../../test-utils/queryTestUtils";
 
-const mockPrograms = [
-  { id: "1", name: "Program A", isSelected: false, gates: [] },
-];
+const mockPrograms = [{ id: "1", name: "Program A" }];
 
 describe("useProgramsQuery", () => {
   beforeEach(() => {

--- a/src/react-app/api/queries/useProgramsQuery.ts
+++ b/src/react-app/api/queries/useProgramsQuery.ts
@@ -8,7 +8,6 @@ const GET_PROGRAMS_QUERY = `
     programs {
       id
       name
-      isSelected
     }
   }
 `;

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from "drizzle-orm";
 import {
+  check,
   index,
   integer,
   real,
@@ -59,7 +60,6 @@ export const sessionProgress = sqliteTable(
     currentGateId: text("current_gate_id").references(() => gates.id, {
       onDelete: "set null",
     }),
-    completedGateIds: text("completed_gate_ids").default("[]"),
     status: text("status").notNull().default("in_progress"),
     startedAt: integer("started_at", { mode: "timestamp" })
       .notNull()
@@ -72,7 +72,34 @@ export const sessionProgress = sqliteTable(
     // Counter for incorrect guesses for the current gate
     attemptCount: integer("attempt_count").notNull().default(0),
   },
-  (t) => [unique("unique_session_progress").on(t.sessionId, t.programId)],
+  (t) => [
+    unique("unique_session_progress").on(t.sessionId, t.programId),
+    check(
+      "session_status_check",
+      sql`${t.status} IN ('in_progress', 'completed')`,
+    ),
+  ],
+);
+
+export const sessionCompletedGates = sqliteTable(
+  "session_completed_gates",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    sessionProgressId: text("session_progress_id")
+      .notNull()
+      .references(() => sessionProgress.id, { onDelete: "cascade" }),
+    gateId: text("gate_id")
+      .notNull()
+      .references(() => gates.id, { onDelete: "cascade" }),
+    completedAt: integer("completed_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (t) => [
+    unique("unique_session_gate_completion").on(t.sessionProgressId, t.gateId),
+  ],
 );
 
 export const gateClues = sqliteTable(
@@ -129,6 +156,21 @@ export const sessionProgressRelations = relations(
       references: [gates.id],
     }),
     gateClues: many(gateClues),
+    completedGates: many(sessionCompletedGates),
+  }),
+);
+
+export const sessionCompletedGatesRelations = relations(
+  sessionCompletedGates,
+  ({ one }) => ({
+    sessionProgress: one(sessionProgress, {
+      fields: [sessionCompletedGates.sessionProgressId],
+      references: [sessionProgress.id],
+    }),
+    gate: one(gates, {
+      fields: [sessionCompletedGates.gateId],
+      references: [gates.id],
+    }),
   }),
 );
 

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -34,10 +34,7 @@ export const gates = sqliteTable(
         sql`(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))`,
       ),
   },
-  (t) => [
-    unique("unique_program_sequence").on(t.programId, t.sequenceOrder),
-    index("gates_program_sequence_idx").on(t.programId, t.sequenceOrder),
-  ],
+  (t) => [unique("unique_program_sequence").on(t.programId, t.sequenceOrder)],
 );
 
 export const programs = sqliteTable("programs", {

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -34,7 +34,10 @@ export const gates = sqliteTable(
         sql`(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))`,
       ),
   },
-  (t) => [unique("unique_program_sequence").on(t.programId, t.sequenceOrder)],
+  (t) => [
+    unique("unique_program_sequence").on(t.programId, t.sequenceOrder),
+    index("gates_program_sequence_idx").on(t.programId, t.sequenceOrder),
+  ],
 );
 
 export const programs = sqliteTable("programs", {

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -19,16 +19,10 @@ export const gates = sqliteTable(
     question: text("question").notNull(),
     correctAnswer: text("correct_answer").notNull(),
     successMessage: text("success_message").notNull(),
-    isSolved: integer("is_solved", { mode: "boolean" })
-      .notNull()
-      .default(false),
-    solvedAt: integer("solved_at", { mode: "timestamp" }),
-    attemptCount: integer("attempt_count").notNull().default(0),
     acceptanceThreshold: real("acceptance_threshold").notNull().default(0.875),
     guidanceEnabled: integer("guidance_enabled", { mode: "boolean" })
       .notNull()
       .default(false),
-    guidancePrompt: text("guidance_prompt"),
     guidanceThreshold: integer("guidance_threshold").notNull().default(2),
     programId: text("program_id")
       .notNull()
@@ -47,22 +41,9 @@ export const programs = sqliteTable("programs", {
     .primaryKey()
     .$defaultFn(() => crypto.randomUUID()),
   name: text("name").notNull(),
-  isSelected: integer("is_selected", { mode: "boolean" })
-    .notNull()
-    .default(false),
-  selectedAt: integer("selected_at", { mode: "timestamp" }),
-  completedAt: integer("completed_at", { mode: "timestamp" }),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .default(sql`(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))`),
-});
-
-export const gameState = sqliteTable("game_state", {
-  id: integer("id").primaryKey().default(1),
-  lastUpdated: integer("last_updated", { mode: "timestamp" })
-    .notNull()
-    .default(sql`(CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))`)
-    .$onUpdateFn(() => new Date()),
 });
 
 export const sessionProgress = sqliteTable(

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -21,6 +21,8 @@ type MockDb = {
   };
   update: ReturnType<typeof vi.fn>;
   insert: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  transaction: ReturnType<typeof vi.fn>;
 };
 
 function createMockDb(): MockDb {
@@ -39,6 +41,15 @@ function createMockDb(): MockDb {
       values: vi.fn().mockReturnValue({
         onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
       }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+    transaction: vi.fn().mockImplementation(function (
+      this: MockDb,
+      cb: (db: MockDb) => unknown,
+    ) {
+      return cb(this);
     }),
   };
 }

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -36,7 +36,9 @@ function createMockDb(): MockDb {
       }),
     }),
     insert: vi.fn().mockReturnValue({
-      values: vi.fn().mockResolvedValue(undefined),
+      values: vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+      }),
     }),
   };
 }
@@ -65,7 +67,6 @@ const defaultProgress = {
   id: "progress-1",
   status: "in_progress",
   currentGateId: "gate-1",
-  completedGateIds: "[]",
   attemptCount: 0,
 };
 

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -79,7 +79,13 @@ export const submitGuess = {
       throw new Error(`Gate with ID ${args.gateId} not found.`);
     }
 
-    if (!isGuessCloseEnough(args.guess, activeGate.correctAnswer)) {
+    if (
+      !isGuessCloseEnough(
+        args.guess,
+        activeGate.correctAnswer,
+        activeGate.acceptanceThreshold,
+      )
+    ) {
       // Atomic increment of attemptCount to prevent race conditions
       await db
         .update(sessionProgress)

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -1,4 +1,9 @@
-import { gateClues, gates, sessionProgress } from "@shared/schema";
+import {
+  gateClues,
+  gates,
+  sessionCompletedGates,
+  sessionProgress,
+} from "@shared/schema";
 import { and, asc, desc, eq, gt, sql } from "drizzle-orm";
 import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from "graphql";
 import { generateClue } from "../../services/aiService";
@@ -141,24 +146,21 @@ export const submitGuess = {
         orderBy: [asc(gates.sequenceOrder)],
       })) || null;
 
-    let completedIds: string[] = [];
-    try {
-      const parsed = JSON.parse(progress.completedGateIds || "[]");
-      if (Array.isArray(parsed)) {
-        completedIds = parsed;
-      }
-    } catch (error) {
-      console.error("Error parsing completedGateIds:", error);
-      throw new Error("Internal server error.");
-    }
-    completedIds.push(activeGate.id);
-
     const newStatus = nextGate ? "in_progress" : "completed";
+
+    // Atomic insert into the join table — unique constraint prevents duplicates
+    await db
+      .insert(sessionCompletedGates)
+      .values({
+        sessionProgressId: progress.id,
+        gateId: activeGate.id,
+      })
+      .onConflictDoNothing();
+
     await db
       .update(sessionProgress)
       .set({
         currentGateId: nextGate ? nextGate.id : null,
-        completedGateIds: JSON.stringify(completedIds),
         status: newStatus,
         attemptCount: 0,
         ...(newStatus === "completed" ? { completedAt: new Date() } : {}),

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -22,7 +22,7 @@ import {
 const MAX_GUESS_LENGTH = 500;
 
 async function getExistingCluesForGate(
-  db: AppGraphQLContext["var"]["db"],
+  db: Omit<AppGraphQLContext["var"]["db"], "batch">,
   sessionProgressId: string,
   gateId: string,
 ) {
@@ -59,120 +59,122 @@ export const submitGuess = {
 
     if (!sessionId) throw new Error("Unauthorized: Missing Session ID");
 
-    const progress = await db.query.sessionProgress.findFirst({
-      where: and(
-        eq(sessionProgress.sessionId, sessionId),
-        eq(sessionProgress.programId, args.programId),
-      ),
-    });
+    return db.transaction(async (tx) => {
+      const progress = await tx.query.sessionProgress.findFirst({
+        where: and(
+          eq(sessionProgress.sessionId, sessionId),
+          eq(sessionProgress.programId, args.programId),
+        ),
+      });
 
-    if (!progress || progress.status === "completed") {
-      throw new Error(
-        "Invalid state: Program already completed or not started.",
-      );
-    }
+      if (!progress || progress.status === "completed") {
+        throw new Error(
+          "Invalid state: Program already completed or not started.",
+        );
+      }
 
-    if (progress.currentGateId !== args.gateId) {
-      throw new Error("Desync: Guess submitted for the wrong active gate.");
-    }
+      if (progress.currentGateId !== args.gateId) {
+        throw new Error("Desync: Guess submitted for the wrong active gate.");
+      }
 
-    const activeGate = await db.query.gates.findFirst({
-      where: eq(gates.id, args.gateId),
-    });
+      const activeGate = await tx.query.gates.findFirst({
+        where: eq(gates.id, args.gateId),
+      });
 
-    if (!activeGate) {
-      throw new Error(`Gate with ID ${args.gateId} not found.`);
-    }
+      if (!activeGate) {
+        throw new Error(`Gate with ID ${args.gateId} not found.`);
+      }
 
-    if (
-      !isGuessCloseEnough(
-        args.guess,
-        activeGate.correctAnswer,
-        activeGate.acceptanceThreshold,
-      )
-    ) {
-      // Atomic increment of attemptCount to prevent race conditions
-      await db
+      if (
+        !isGuessCloseEnough(
+          args.guess,
+          activeGate.correctAnswer,
+          activeGate.acceptanceThreshold,
+        )
+      ) {
+        // Atomic increment of attemptCount to prevent race conditions
+        await tx
+          .update(sessionProgress)
+          .set({
+            attemptCount: sql`${sessionProgress.attemptCount} + 1`,
+          })
+          .where(eq(sessionProgress.id, progress.id));
+
+        // Re-fetch to get the incremented value
+        const updatedProgress = await tx.query.sessionProgress.findFirst({
+          where: eq(sessionProgress.id, progress.id),
+        });
+
+        if (!updatedProgress) {
+          throw new Error("Failed to update attempt count.");
+        }
+
+        const existingClues = await getExistingCluesForGate(
+          tx,
+          progress.id,
+          args.gateId,
+        );
+        const mostRecentClueAttemptCount =
+          existingClues[0]?.attemptCountAtRequest ?? null;
+
+        const canRequestClue = computeCanRequestClue({
+          isCorrectGuess: false,
+          guidanceEnabled: activeGate.guidanceEnabled,
+          attemptCount: updatedProgress.attemptCount,
+          guidanceThreshold: activeGate.guidanceThreshold,
+          existingClueCount: existingClues.length,
+          mostRecentClueAttemptCount,
+        });
+
+        return {
+          success: false,
+          message: "ACCESS DENIED. INCORRECT SYNTAX OR VALUE.",
+          nextGate: null,
+          canRequestClue,
+        };
+      }
+
+      // Guess is correct! Advance the state.
+      const nextGate =
+        (await tx.query.gates.findFirst({
+          columns: {
+            correctAnswer: false,
+          },
+          where: and(
+            eq(gates.programId, args.programId),
+            gt(gates.sequenceOrder, activeGate.sequenceOrder), // > current gate
+          ),
+          orderBy: [asc(gates.sequenceOrder)],
+        })) || null;
+
+      const newStatus = nextGate ? "in_progress" : "completed";
+
+      // Atomic insert into the join table — unique constraint prevents duplicates
+      await tx
+        .insert(sessionCompletedGates)
+        .values({
+          sessionProgressId: progress.id,
+          gateId: activeGate.id,
+        })
+        .onConflictDoNothing();
+
+      await tx
         .update(sessionProgress)
         .set({
-          attemptCount: sql`${sessionProgress.attemptCount} + 1`,
+          currentGateId: nextGate ? nextGate.id : null,
+          status: newStatus,
+          attemptCount: 0,
+          ...(newStatus === "completed" ? { completedAt: new Date() } : {}),
         })
         .where(eq(sessionProgress.id, progress.id));
 
-      // Re-fetch to get the incremented value
-      const updatedProgress = await db.query.sessionProgress.findFirst({
-        where: eq(sessionProgress.id, progress.id),
-      });
-
-      if (!updatedProgress) {
-        throw new Error("Failed to update attempt count.");
-      }
-
-      const existingClues = await getExistingCluesForGate(
-        db,
-        progress.id,
-        args.gateId,
-      );
-      const mostRecentClueAttemptCount =
-        existingClues[0]?.attemptCountAtRequest ?? null;
-
-      const canRequestClue = computeCanRequestClue({
-        isCorrectGuess: false,
-        guidanceEnabled: activeGate.guidanceEnabled,
-        attemptCount: updatedProgress.attemptCount,
-        guidanceThreshold: activeGate.guidanceThreshold,
-        existingClueCount: existingClues.length,
-        mostRecentClueAttemptCount,
-      });
-
       return {
-        success: false,
-        message: "ACCESS DENIED. INCORRECT SYNTAX OR VALUE.",
-        nextGate: null,
-        canRequestClue,
+        success: true,
+        message: activeGate.successMessage,
+        nextGate,
+        canRequestClue: false,
       };
-    }
-
-    // Guess is correct! Advance the state.
-    const nextGate =
-      (await db.query.gates.findFirst({
-        columns: {
-          correctAnswer: false,
-        },
-        where: and(
-          eq(gates.programId, args.programId),
-          gt(gates.sequenceOrder, activeGate.sequenceOrder), // > current gate
-        ),
-        orderBy: [asc(gates.sequenceOrder)],
-      })) || null;
-
-    const newStatus = nextGate ? "in_progress" : "completed";
-
-    // Atomic insert into the join table — unique constraint prevents duplicates
-    await db
-      .insert(sessionCompletedGates)
-      .values({
-        sessionProgressId: progress.id,
-        gateId: activeGate.id,
-      })
-      .onConflictDoNothing();
-
-    await db
-      .update(sessionProgress)
-      .set({
-        currentGateId: nextGate ? nextGate.id : null,
-        status: newStatus,
-        attemptCount: 0,
-        ...(newStatus === "completed" ? { completedAt: new Date() } : {}),
-      })
-      .where(eq(sessionProgress.id, progress.id));
-
-    return {
-      success: true,
-      message: activeGate.successMessage,
-      nextGate,
-      canRequestClue: false,
-    };
+    });
   },
 };
 

--- a/src/worker/graphql/gameplay/queries.spec.ts
+++ b/src/worker/graphql/gameplay/queries.spec.ts
@@ -11,6 +11,7 @@ describe("Gameplay Queries: getProgramProgression", () => {
       query: {
         gates: { findMany: vi.fn(), findFirst: vi.fn() },
         sessionProgress: { findFirst: vi.fn() },
+        sessionCompletedGates: { findMany: vi.fn() },
       },
       insert: vi.fn(),
     } as unknown;
@@ -38,10 +39,14 @@ describe("Gameplay Queries: getProgramProgression", () => {
   it("fetches and returns the correct progression state", async () => {
     // @ts-expect-error
     mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      completedGateIds: JSON.stringify(["gate-1"]),
       currentGateId: "gate-2",
       status: "in_progress",
     });
+
+    // @ts-expect-error
+    mockDb.query.sessionCompletedGates.findMany.mockResolvedValue([
+      { gateId: "gate-1" },
+    ]);
 
     // @ts-expect-error
     mockDb.query.gates.findMany.mockResolvedValue([
@@ -96,10 +101,12 @@ describe("Gameplay Queries: getProgramProgression", () => {
   it("skips completed gate query when none are completed", async () => {
     // @ts-expect-error
     mockDb.query.sessionProgress.findFirst.mockResolvedValue({
-      completedGateIds: "[]",
       currentGateId: "gate-1",
       status: "in_progress",
     });
+
+    // @ts-expect-error
+    mockDb.query.sessionCompletedGates.findMany.mockResolvedValue([]);
 
     // @ts-expect-error
     mockDb.query.gates.findFirst.mockResolvedValue({

--- a/src/worker/graphql/gameplay/queries.ts
+++ b/src/worker/graphql/gameplay/queries.ts
@@ -141,7 +141,6 @@ export const getPrograms = {
       columns: {
         id: true,
         name: true,
-        isSelected: true,
       },
     });
   },

--- a/src/worker/graphql/gameplay/queries.ts
+++ b/src/worker/graphql/gameplay/queries.ts
@@ -1,4 +1,4 @@
-import { gates, sessionProgress } from "@shared/schema";
+import { gates, sessionCompletedGates, sessionProgress } from "@shared/schema";
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import { GraphQLList, GraphQLNonNull, GraphQLString } from "graphql";
 import {
@@ -49,7 +49,6 @@ export const getProgramProgression = {
             sessionId,
             programId: args.programId,
             currentGateId: firstGate.id,
-            completedGateIds: "[]",
           })
           .returning();
         progress = newProgress[0];
@@ -66,24 +65,21 @@ export const getProgramProgression = {
       }
     }
 
-    let completedIds: string[] = [];
-    try {
-      const parsed = JSON.parse(progress.completedGateIds || "[]");
-      if (Array.isArray(parsed)) {
-        completedIds = parsed;
-      }
-    } catch (error) {
-      console.error("Error parsing completedGateIds:", error);
-      throw new Error("Internal server error.");
-    }
-    // Security: only gates in completedGateIds are fetched with correctAnswer.
+    // Security: only gates from sessionCompletedGates are fetched with correctAnswer.
+    const completedEntries = await db.query.sessionCompletedGates.findMany({
+      where: eq(sessionCompletedGates.sessionProgressId, progress.id),
+    });
+
     const completedGates =
-      completedIds.length === 0
+      completedEntries.length === 0
         ? []
         : await db.query.gates.findMany({
             where: and(
               eq(gates.programId, args.programId),
-              inArray(gates.id, completedIds),
+              inArray(
+                gates.id,
+                completedEntries.map((e) => e.gateId),
+              ),
             ),
             orderBy: [asc(gates.sequenceOrder)],
           });

--- a/src/worker/graphql/gameplay/types.ts
+++ b/src/worker/graphql/gameplay/types.ts
@@ -16,7 +16,6 @@ export const ProgramListItemType = new GraphQLObjectType({
   fields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
     name: { type: new GraphQLNonNull(GraphQLString) },
-    isSelected: { type: new GraphQLNonNull(GraphQLBoolean) },
   },
 });
 


### PR DESCRIPTION
- **♻️ refactor(schema): drop obsolete gate and program columns, remove game_state**
- **♻️ refactor(programs): remove isSelected field from program queries**
- **✨ feat(graphql-gameplay): pass acceptanceThreshold to guess check**
- **✨ feat(schema): add session completed gates table with constraints**
- **♻️ refactor(gameplay): use join table for completed gates**
- **✨ feat(gameplay-queries): replace JSON completedGateIds with sessionCompletedGates table**
- **✨ feat(db): add non-unique index for gates program sequence**

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session progress tracking by recording completed gates individually.
  * Added clearer session status validation and progression handling.
  * Improved guess acceptance validation.

* **Bug Fixes**
  * Prevented duplicate completion records during gameplay.
  * Removed outdated program selection data from program listings.
  * Improved gate progression data retrieval and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->