### PR TITLE
♻️ refactor(project-structure): use alias imports for routes and modules

### DIFF
--- a/src/react-app/components/ProgramPlay.spec.tsx
+++ b/src/react-app/components/ProgramPlay.spec.tsx
@@ -21,7 +21,7 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: vi.fn(() => vi.fn()),
 }));
 
-vi.mock("../routes/programs/$programId", () => ({
+vi.mock("@routes/programs/$programId", () => ({
   Route: {
     useParams: vi.fn(() => ({ programId: "test-program-id" })),
     fullPath: "/programs/test-program-id",

--- a/src/react-app/components/ProgramPlay.tsx
+++ b/src/react-app/components/ProgramPlay.tsx
@@ -5,10 +5,10 @@ import CompletedGate from "@components/CompletedGate";
 import TerminalConfirmModal from "@components/TerminalConfirmModal";
 import useProgramPlay from "@hooks/useProgramPlay";
 import useProgressionScroll from "@hooks/useProgressionScroll";
+import { Route } from "@routes/programs/$programId";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
-import { Route } from "../routes/programs/$programId";
 import styles from "./ProgramPlay.module.css";
 
 function ProgramPlay() {

--- a/src/react-app/components/ProgramSelector.spec.tsx
+++ b/src/react-app/components/ProgramSelector.spec.tsx
@@ -1,10 +1,10 @@
 // src/react-app/components/ProgramSelector.spec.tsx
 import usePrograms from "@hooks/usePrograms";
+import { Route } from "@routes/programs/select";
 import { useNavigate } from "@tanstack/react-router";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
-import { Route } from "../routes/programs/select";
 import ProgramSelector from "./ProgramSelector";
 
 vi.mock("@hooks/usePrograms");
@@ -13,7 +13,7 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: vi.fn(),
 }));
 
-vi.mock("../routes/programs/select", () => ({
+vi.mock("@routes/programs/select", () => ({
   Route: {
     useSearch: vi.fn(),
     fullPath: "/programs/select",

--- a/src/react-app/components/ProgramSelector.tsx
+++ b/src/react-app/components/ProgramSelector.tsx
@@ -1,7 +1,7 @@
 import usePrograms from "@hooks/usePrograms";
+import { Route } from "@routes/programs/select";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
-import { Route } from "../routes/programs/select";
 import styles from "./ProgramSelector.module.css";
 
 function ProgramSelector() {

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { requestClue, submitGuess } from "./mutations";
 
-vi.mock("../../utils/isGuessCloseEnough", () => ({
+vi.mock("@worker-utils/isGuessCloseEnough", () => ({
   default: vi.fn(),
 }));
 
-vi.mock("../../services/aiService", () => ({
+vi.mock("@worker-services/aiService", () => ({
   generateClue: vi.fn(),
 }));
 
-import { generateClue } from "../../services/aiService";
-import isGuessCloseEnough from "../../utils/isGuessCloseEnough";
+import { generateClue } from "@worker-services/aiService";
+import isGuessCloseEnough from "@worker-utils/isGuessCloseEnough";
 import type { AppGraphQLContext } from "./types";
 
 type MockDb = {

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -22,7 +22,7 @@ type MockDb = {
   update: ReturnType<typeof vi.fn>;
   insert: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
-  transaction: ReturnType<typeof vi.fn>;
+  batch: ReturnType<typeof vi.fn>;
 };
 
 function createMockDb(): MockDb {
@@ -45,11 +45,8 @@ function createMockDb(): MockDb {
     delete: vi.fn().mockReturnValue({
       where: vi.fn().mockResolvedValue(undefined),
     }),
-    transaction: vi.fn().mockImplementation(function (
-      this: MockDb,
-      cb: (db: MockDb) => unknown,
-    ) {
-      return cb(this);
+    batch: vi.fn().mockImplementation((statements: Promise<unknown>[]) => {
+      return Promise.all(statements);
     }),
   };
 }

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -22,7 +22,7 @@ import {
 const MAX_GUESS_LENGTH = 500;
 
 async function getExistingCluesForGate(
-  db: Omit<AppGraphQLContext["var"]["db"], "batch">,
+  db: AppGraphQLContext["var"]["db"],
   sessionProgressId: string,
   gateId: string,
 ) {
@@ -59,106 +59,109 @@ export const submitGuess = {
 
     if (!sessionId) throw new Error("Unauthorized: Missing Session ID");
 
-    return db.transaction(async (tx) => {
-      const progress = await tx.query.sessionProgress.findFirst({
+    // NOTE: D1 does not support SQL BEGIN/SAVEPOINT, so db.transaction()
+    // always fails here. Reads run directly on `db`; writes that must
+    // land together are grouped with db.batch() instead.
+    const progress = await db.query.sessionProgress.findFirst({
+      where: and(
+        eq(sessionProgress.sessionId, sessionId),
+        eq(sessionProgress.programId, args.programId),
+      ),
+    });
+
+    if (!progress || progress.status === "completed") {
+      throw new Error(
+        "Invalid state: Program already completed or not started.",
+      );
+    }
+
+    if (progress.currentGateId !== args.gateId) {
+      throw new Error("Desync: Guess submitted for the wrong active gate.");
+    }
+
+    const activeGate = await db.query.gates.findFirst({
+      where: eq(gates.id, args.gateId),
+    });
+
+    if (!activeGate) {
+      throw new Error(`Gate with ID ${args.gateId} not found.`);
+    }
+
+    if (
+      !isGuessCloseEnough(
+        args.guess,
+        activeGate.correctAnswer,
+        activeGate.acceptanceThreshold,
+      )
+    ) {
+      // Atomic increment of attemptCount to prevent race conditions
+      await db
+        .update(sessionProgress)
+        .set({
+          attemptCount: sql`${sessionProgress.attemptCount} + 1`,
+        })
+        .where(eq(sessionProgress.id, progress.id));
+
+      // Re-fetch to get the incremented value
+      const updatedProgress = await db.query.sessionProgress.findFirst({
+        where: eq(sessionProgress.id, progress.id),
+      });
+
+      if (!updatedProgress) {
+        throw new Error("Failed to update attempt count.");
+      }
+
+      const existingClues = await getExistingCluesForGate(
+        db,
+        progress.id,
+        args.gateId,
+      );
+      const mostRecentClueAttemptCount =
+        existingClues[0]?.attemptCountAtRequest ?? null;
+
+      const canRequestClue = computeCanRequestClue({
+        isCorrectGuess: false,
+        guidanceEnabled: activeGate.guidanceEnabled,
+        attemptCount: updatedProgress.attemptCount,
+        guidanceThreshold: activeGate.guidanceThreshold,
+        existingClueCount: existingClues.length,
+        mostRecentClueAttemptCount,
+      });
+
+      return {
+        success: false,
+        message: "ACCESS DENIED. INCORRECT SYNTAX OR VALUE.",
+        nextGate: null,
+        canRequestClue,
+      };
+    }
+
+    // Guess is correct! Advance the state.
+    const nextGate =
+      (await db.query.gates.findFirst({
+        columns: {
+          correctAnswer: false,
+        },
         where: and(
-          eq(sessionProgress.sessionId, sessionId),
-          eq(sessionProgress.programId, args.programId),
+          eq(gates.programId, args.programId),
+          gt(gates.sequenceOrder, activeGate.sequenceOrder), // > current gate
         ),
-      });
+        orderBy: [asc(gates.sequenceOrder)],
+      })) || null;
 
-      if (!progress || progress.status === "completed") {
-        throw new Error(
-          "Invalid state: Program already completed or not started.",
-        );
-      }
+    const newStatus = nextGate ? "in_progress" : "completed";
 
-      if (progress.currentGateId !== args.gateId) {
-        throw new Error("Desync: Guess submitted for the wrong active gate.");
-      }
-
-      const activeGate = await tx.query.gates.findFirst({
-        where: eq(gates.id, args.gateId),
-      });
-
-      if (!activeGate) {
-        throw new Error(`Gate with ID ${args.gateId} not found.`);
-      }
-
-      if (
-        !isGuessCloseEnough(
-          args.guess,
-          activeGate.correctAnswer,
-          activeGate.acceptanceThreshold,
-        )
-      ) {
-        // Atomic increment of attemptCount to prevent race conditions
-        await tx
-          .update(sessionProgress)
-          .set({
-            attemptCount: sql`${sessionProgress.attemptCount} + 1`,
-          })
-          .where(eq(sessionProgress.id, progress.id));
-
-        // Re-fetch to get the incremented value
-        const updatedProgress = await tx.query.sessionProgress.findFirst({
-          where: eq(sessionProgress.id, progress.id),
-        });
-
-        if (!updatedProgress) {
-          throw new Error("Failed to update attempt count.");
-        }
-
-        const existingClues = await getExistingCluesForGate(
-          tx,
-          progress.id,
-          args.gateId,
-        );
-        const mostRecentClueAttemptCount =
-          existingClues[0]?.attemptCountAtRequest ?? null;
-
-        const canRequestClue = computeCanRequestClue({
-          isCorrectGuess: false,
-          guidanceEnabled: activeGate.guidanceEnabled,
-          attemptCount: updatedProgress.attemptCount,
-          guidanceThreshold: activeGate.guidanceThreshold,
-          existingClueCount: existingClues.length,
-          mostRecentClueAttemptCount,
-        });
-
-        return {
-          success: false,
-          message: "ACCESS DENIED. INCORRECT SYNTAX OR VALUE.",
-          nextGate: null,
-          canRequestClue,
-        };
-      }
-
-      // Guess is correct! Advance the state.
-      const nextGate =
-        (await tx.query.gates.findFirst({
-          columns: {
-            correctAnswer: false,
-          },
-          where: and(
-            eq(gates.programId, args.programId),
-            gt(gates.sequenceOrder, activeGate.sequenceOrder), // > current gate
-          ),
-          orderBy: [asc(gates.sequenceOrder)],
-        })) || null;
-
-      const newStatus = nextGate ? "in_progress" : "completed";
-
-      // Atomic insert into the join table — unique constraint prevents duplicates
-      await tx
+    // Both writes must land together — group via D1 batch (sequential,
+    // all-or-nothing), since db.transaction() isn't supported.
+    await db.batch([
+      db
         .insert(sessionCompletedGates)
         .values({
           sessionProgressId: progress.id,
           gateId: activeGate.id,
         })
-        .onConflictDoNothing();
-
-      await tx
+        .onConflictDoNothing(),
+      db
         .update(sessionProgress)
         .set({
           currentGateId: nextGate ? nextGate.id : null,
@@ -166,15 +169,15 @@ export const submitGuess = {
           attemptCount: 0,
           ...(newStatus === "completed" ? { completedAt: new Date() } : {}),
         })
-        .where(eq(sessionProgress.id, progress.id));
+        .where(eq(sessionProgress.id, progress.id)),
+    ]);
 
-      return {
-        success: true,
-        message: activeGate.successMessage,
-        nextGate,
-        canRequestClue: false,
-      };
-    });
+    return {
+      success: true,
+      message: activeGate.successMessage,
+      nextGate,
+      canRequestClue: false,
+    };
   },
 };
 

--- a/src/worker/graphql/gameplay/mutations.ts
+++ b/src/worker/graphql/gameplay/mutations.ts
@@ -4,10 +4,10 @@ import {
   sessionCompletedGates,
   sessionProgress,
 } from "@shared/schema";
+import { generateClue } from "@worker-services/aiService";
+import isGuessCloseEnough from "@worker-utils/isGuessCloseEnough";
 import { and, asc, desc, eq, gt, sql } from "drizzle-orm";
 import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from "graphql";
-import { generateClue } from "../../services/aiService";
-import isGuessCloseEnough from "../../utils/isGuessCloseEnough";
 import {
   computeCanRequestClue,
   computeCluesRemaining,

--- a/src/worker/graphql/gameplay/types.ts
+++ b/src/worker/graphql/gameplay/types.ts
@@ -1,3 +1,4 @@
+import type { AppVariables } from "@worker-middleware/db";
 import {
   GraphQLBoolean,
   GraphQLInt,
@@ -7,7 +8,6 @@ import {
   GraphQLString,
 } from "graphql";
 import type { Context } from "hono";
-import type { AppVariables } from "../../middleware/db";
 
 export type AppGraphQLContext = Context<AppVariables>;
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,10 +1,10 @@
 import type { Ai, D1Database } from "@cloudflare/workers-types";
+import { type AppVariables, setupDb } from "@worker-middleware/db";
+import { conditionalLogger } from "@worker-middleware/logger";
+import { sessionMiddleware } from "@worker-middleware/session";
+import graphQlRouter from "@worker-routes/graphql";
+import { formatErrorResponse, logError } from "@worker-utils/errorHandler";
 import { Hono } from "hono";
-import { type AppVariables, setupDb } from "./middleware/db";
-import { conditionalLogger } from "./middleware/logger";
-import { sessionMiddleware } from "./middleware/session";
-import graphQlRouter from "./routes/graphql";
-import { formatErrorResponse, logError } from "./utils/errorHandler";
 
 export type Env = {
   Bindings: {

--- a/src/worker/routes/graphql.spec.ts
+++ b/src/worker/routes/graphql.spec.ts
@@ -1,7 +1,7 @@
+import { setupDb } from "@worker-middleware/db";
 import { type Context, Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "..";
-import { setupDb } from "../middleware/db";
 import { invalidateCachedSchema } from "./graphql";
 
 vi.mock("@hono/graphql-server", () => ({

--- a/src/worker/routes/graphql.ts
+++ b/src/worker/routes/graphql.ts
@@ -1,4 +1,15 @@
 import { graphqlServer } from "@hono/graphql-server";
+import {
+  requestClue,
+  resetSession,
+  submitGuess,
+} from "@worker-graphql/gameplay/mutations";
+import {
+  getInProgressProgram,
+  getProgramProgression,
+  getPrograms,
+} from "@worker-graphql/gameplay/queries";
+import type { AppVariables } from "@worker-middleware/db";
 import { buildSchema } from "drizzle-graphql";
 import {
   GraphQLObjectType,
@@ -6,17 +17,6 @@ import {
   NoSchemaIntrospectionCustomRule,
 } from "graphql";
 import { Hono } from "hono";
-import {
-  requestClue,
-  resetSession,
-  submitGuess,
-} from "../graphql/gameplay/mutations";
-import {
-  getInProgressProgram,
-  getProgramProgression,
-  getPrograms,
-} from "../graphql/gameplay/queries";
-import type { AppVariables } from "../middleware/db";
 
 let cachedSchema: GraphQLSchema | null = null;
 

--- a/src/worker/services/aiService.spec.ts
+++ b/src/worker/services/aiService.spec.ts
@@ -1,5 +1,5 @@
+import { createMockHonoContext } from "@worker-test-utils/mockEnv";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockHonoContext } from "../test-utils/mockEnv";
 import { generateClue } from "./aiService";
 
 vi.mock("hono/adapter", () => ({

--- a/src/worker/test-utils/mockEnv.ts
+++ b/src/worker/test-utils/mockEnv.ts
@@ -1,7 +1,7 @@
 import type { Ai, D1Database } from "@cloudflare/workers-types";
 import type { Context } from "hono";
 import { type Mock, vi } from "vitest";
-import type { Env } from "../index";
+import type { Env } from "..";
 
 export function createMockEnv(
   overrides: Partial<Env["Bindings"]> = {},

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -12,9 +12,15 @@
       "@hooks/*": ["./src/react-app/hooks/*"],
       "@components/*": ["./src/react-app/components/*"],
       "@contexts/*": ["./src/react-app/contexts/*"],
+      "@routes/*": ["./src/react-app/routes/*"],
       "@utils/*": ["./src/react-app/utils/*"],
       "@test-utils/*": ["./src/react-app/test-utils/*"],
-      "@worker/*": ["./src/worker/*"],
+      "@worker-routes/*": ["./src/worker/routes/*"],
+      "@worker-middleware/*": ["./src/worker/middleware/*"],
+      "@worker-services/*": ["./src/worker/services/*"],
+      "@worker-utils/*": ["./src/worker/utils/*"],
+      "@worker-graphql/*": ["./src/worker/graphql/*"],
+      "@worker-test-utils/*": ["./src/worker/test-utils/*"],
       "@shared/*": ["./src/shared/*"]
     },
 

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -5,7 +5,13 @@
     "types": ["vite/client", "./worker-configuration.d.ts", "node"],
 
     "paths": {
-      "@shared/*": ["./src/shared/*"]
+      "@shared/*": ["./src/shared/*"],
+      "@worker-routes/*": ["./src/worker/routes/*"],
+      "@worker-middleware/*": ["./src/worker/middleware/*"],
+      "@worker-services/*": ["./src/worker/services/*"],
+      "@worker-utils/*": ["./src/worker/utils/*"],
+      "@worker-graphql/*": ["./src/worker/graphql/*"],
+      "@worker-test-utils/*": ["./src/worker/test-utils/*"]
     }
   },
   "include": ["src/worker", "src/shared"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,12 +23,32 @@ export default defineConfig({
       "@components": fileURLToPath(
         new URL("./src/react-app/components", import.meta.url),
       ),
+      "@routes": fileURLToPath(
+        new URL("./src/react-app/routes", import.meta.url),
+      ),
       "@utils": fileURLToPath(
         new URL("./src/react-app/utils", import.meta.url),
       ),
       "@api": fileURLToPath(new URL("./src/react-app/api", import.meta.url)),
       "@shared": fileURLToPath(new URL("./src/shared", import.meta.url)),
-      "@worker": fileURLToPath(new URL("./src/worker", import.meta.url)),
+      "@worker-routes": fileURLToPath(
+        new URL("./src/worker/routes", import.meta.url),
+      ),
+      "@worker-middleware": fileURLToPath(
+        new URL("./src/worker/middleware", import.meta.url),
+      ),
+      "@worker-services": fileURLToPath(
+        new URL("./src/worker/services", import.meta.url),
+      ),
+      "@worker-utils": fileURLToPath(
+        new URL("./src/worker/utils", import.meta.url),
+      ),
+      "@worker-graphql": fileURLToPath(
+        new URL("./src/worker/graphql", import.meta.url),
+      ),
+      "@worker-test-utils": fileURLToPath(
+        new URL("./src/worker/test-utils", import.meta.url),
+      ),
     },
   },
   build: {


### PR DESCRIPTION
Closes #44 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized module imports across the application and worker services.
  * Added clearer aliases for routes, middleware, services, utilities, GraphQL modules, and test helpers.
  * Improved consistency between application and worker build configurations.

* **Tests**
  * Updated test mocks and imports to use the new module aliases.
  * Existing test behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->