### PR TITLE
✅ test(e2e): add reset flow and wrong answer tests

### DIFF
--- a/e2e/pages/gamePage.ts
+++ b/e2e/pages/gamePage.ts
@@ -185,7 +185,16 @@ export class GamePage {
   async waitForDenial(): Promise<string | null> {
     const status = this.page.locator("[role='status']");
     try {
-      await status.waitFor({ state: "visible", timeout: 10000 });
+      await this.page.waitForFunction(
+        () => {
+          const el = document.querySelector("[role='status']");
+          if (!el) return false;
+          const text = el.textContent || "";
+          return text.includes("ACCESS DENIED");
+        },
+        undefined,
+        { timeout: 15000 },
+      );
       return (await status.textContent())?.trim() ?? null;
     } catch {
       return null;
@@ -198,7 +207,7 @@ export class GamePage {
    */
   async submitAnswerAndWaitForDenial(answer: string): Promise<string | null> {
     await this.submitAnswer(answer);
-    return this.waitForVerificationComplete();
+    return this.waitForDenial();
   }
 
   /**

--- a/e2e/pages/gamePage.ts
+++ b/e2e/pages/gamePage.ts
@@ -175,4 +175,123 @@ export class GamePage {
       return null;
     }
   }
+
+  // ─── Wrong answer helpers ──────────────────────────────────────────
+
+  /**
+   * Wait for the denial message after a wrong answer.
+   * Expected text: "ACCESS DENIED. INCORRECT SYNTAX OR VALUE."
+   */
+  async waitForDenial(): Promise<string | null> {
+    const status = this.page.locator("[role='status']");
+    try {
+      await status.waitFor({ state: "visible", timeout: 10000 });
+      return (await status.textContent())?.trim() ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Submit an answer and wait for the denial message.
+   * Returns the denial message text (or null if timeout).
+   */
+  async submitAnswerAndWaitForDenial(answer: string): Promise<string | null> {
+    await this.submitAnswer(answer);
+    return this.waitForVerificationComplete();
+  }
+
+  /**
+   * Check if the active gate div currently has the shake CSS class.
+   * Note: shake auto-clears after ~400ms, so call this immediately
+   * after a wrong answer submission.
+   */
+  async isShaking(): Promise<boolean> {
+    return this.page.locator("[class*='shake']").first().isVisible();
+  }
+
+  // ─── Clue button helpers ───────────────────────────────────────────
+
+  /**
+   * Get the clue button locator (if visible).
+   * Button text is "Get 1st Clue", "Get 2nd Clue", or "Get Final Clue".
+   */
+  getClueButtonLocator() {
+    return this.page.locator("button", { hasText: "Clue" });
+  }
+
+  /**
+   * Check if the clue button is currently visible.
+   */
+  async isClueButtonVisible(): Promise<boolean> {
+    return this.getClueButtonLocator().isVisible();
+  }
+
+  /**
+   * Wait for clue text to appear in the clues list.
+   * Returns the first clue line text.
+   */
+  async waitForClueText(): Promise<string | null> {
+    const clueLine = this.page.locator("p.clueLine").first();
+    try {
+      await clueLine.waitFor({ state: "visible", timeout: 15000 });
+      return (await clueLine.textContent())?.trim() ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  // ─── End-state action helpers ──────────────────────────────────────
+
+  /**
+   * Click "Play program again" button at The End screen.
+   * Resets the session and returns to gate 1.
+   */
+  async clickPlayAgain(): Promise<void> {
+    await this.page.locator('button[title="Play program again"]').click();
+  }
+
+  /**
+   * Click "Select new program" button at The End screen.
+   * Opens the TerminalConfirmModal.
+   */
+  async clickSelectNewProgram(): Promise<void> {
+    await this.page.locator('button[title="Select new program"]').click();
+  }
+
+  // ─── TerminalConfirmModal helpers ──────────────────────────────────
+
+  /**
+   * Check if the reset confirmation dialog is visible.
+   */
+  async isConfirmModalVisible(): Promise<boolean> {
+    const dialog = this.page.locator(
+      'dialog[aria-label="Reset Progress Confirmation"]',
+    );
+    return dialog.isVisible();
+  }
+
+  /**
+   * Click "Reset Progress" in the confirmation modal.
+   * Resets the session and navigates to /programs/select.
+   */
+  async confirmReset(): Promise<void> {
+    await this.page.getByRole("button", { name: "Reset Progress" }).click();
+  }
+
+  /**
+   * Click "Keep Progress" in the confirmation modal.
+   * Navigates to /programs/select without resetting.
+   */
+  async keepProgress(): Promise<void> {
+    await this.page.getByRole("button", { name: "Keep Progress" }).click();
+  }
+
+  /**
+   * Click "[x]" (Cancel) in the confirmation modal.
+   * Closes the modal without action.
+   */
+  async cancelReset(): Promise<void> {
+    await this.page.getByRole("button", { name: "[x]" }).click();
+  }
 }

--- a/e2e/reset-flow.spec.ts
+++ b/e2e/reset-flow.spec.ts
@@ -1,0 +1,96 @@
+import { expect, type Page, test } from "@playwright/test";
+import type { GamePage } from "./pages/gamePage";
+import { SelectProgramPage } from "./pages/selectProgramPage";
+
+/**
+ * Play through all 3 gates of the E2E Test Program.
+ * Returns the GamePage at "The End" state.
+ */
+async function completeE2EProgram(page: Page): Promise<GamePage> {
+  const selectPage = new SelectProgramPage(page);
+  await selectPage.goto();
+  await selectPage.waitForLoad();
+  const gamePage = await selectPage.selectAndStart("E2E Test Program");
+  await gamePage.waitForLoad();
+
+  // Gate 1: "blue"
+  await gamePage.submitAnswer("blue");
+  const r1 = await gamePage.waitForVerificationComplete();
+  expect(r1).toContain("Correct!");
+  await gamePage.waitForActiveGateLabel("Gate 2");
+
+  // Gate 2: "4"
+  await gamePage.submitAnswer("4");
+  const r2 = await gamePage.waitForVerificationComplete();
+  expect(r2).toContain("Correct!");
+  await gamePage.waitForActiveGateLabel("Gate 3");
+
+  // Gate 3: "cold"
+  await gamePage.submitAnswer("cold");
+  const r3 = await gamePage.waitForVerificationComplete();
+  expect(r3).toContain("Correct!");
+  await gamePage.waitForTheEnd();
+
+  return gamePage;
+}
+
+test.describe("@full reset flow", () => {
+  test("Play again resets session and returns to Gate 1", async ({ page }) => {
+    const gamePage = await completeE2EProgram(page);
+
+    await gamePage.clickPlayAgain();
+    await gamePage.waitForActiveGateLabel("Gate 1");
+
+    const label = await gamePage.getActiveGateLabel();
+    expect(label).toBe("Gate 1");
+  });
+
+  test("Select new program → Keep Progress navigates to /programs/select", async ({
+    page,
+  }) => {
+    const gamePage = await completeE2EProgram(page);
+
+    await gamePage.clickSelectNewProgram();
+    expect(await gamePage.isConfirmModalVisible()).toBe(true);
+
+    await gamePage.keepProgress();
+
+    // Should land on program select page
+    const selectPage = new SelectProgramPage(page);
+    await selectPage.waitForLoad();
+  });
+
+  test("Select new program → Cancel ([x]) closes modal, stays at The End", async ({
+    page,
+  }) => {
+    const gamePage = await completeE2EProgram(page);
+
+    await gamePage.clickSelectNewProgram();
+    expect(await gamePage.isConfirmModalVisible()).toBe(true);
+
+    await gamePage.cancelReset();
+    expect(await gamePage.isConfirmModalVisible()).toBe(false);
+    expect(await gamePage.isGameComplete()).toBe(true);
+  });
+
+  test("Select new program → Reset Progress resets session and navigates to /programs/select", async ({
+    page,
+  }) => {
+    const gamePage = await completeE2EProgram(page);
+
+    await gamePage.clickSelectNewProgram();
+    expect(await gamePage.isConfirmModalVisible()).toBe(true);
+
+    await gamePage.confirmReset();
+
+    // Should land on program select page
+    const selectPage = new SelectProgramPage(page);
+    await selectPage.waitForLoad();
+
+    // Re-select and verify session was truly reset (back at Gate 1)
+    const resetGamePage = await selectPage.selectAndStart("E2E Test Program");
+    await resetGamePage.waitForActiveGateLabel("Gate 1");
+    const label = await resetGamePage.getActiveGateLabel();
+    expect(label).toBe("Gate 1");
+  });
+});

--- a/e2e/reset-flow.spec.ts
+++ b/e2e/reset-flow.spec.ts
@@ -45,9 +45,7 @@ test.describe("@full reset flow", () => {
     expect(label).toBe("Gate 1");
   });
 
-  test("Select new program → Keep Progress navigates to /programs/select", async ({
-    page,
-  }) => {
+  test("Select new → Keep preserves completed state", async ({ page }) => {
     const gamePage = await completeE2EProgram(page);
 
     await gamePage.clickSelectNewProgram();
@@ -58,11 +56,13 @@ test.describe("@full reset flow", () => {
     // Should land on program select page
     const selectPage = new SelectProgramPage(page);
     await selectPage.waitForLoad();
+
+    // Re-select and verify progress is preserved (still at The End)
+    const resumedGamePage = await selectPage.selectAndStart("E2E Test Program");
+    await resumedGamePage.waitForTheEnd();
   });
 
-  test("Select new program → Cancel ([x]) closes modal, stays at The End", async ({
-    page,
-  }) => {
+  test("Select new → Cancel ([x]) closes modal", async ({ page }) => {
     const gamePage = await completeE2EProgram(page);
 
     await gamePage.clickSelectNewProgram();
@@ -73,9 +73,7 @@ test.describe("@full reset flow", () => {
     expect(await gamePage.isGameComplete()).toBe(true);
   });
 
-  test("Select new program → Reset Progress resets session and navigates to /programs/select", async ({
-    page,
-  }) => {
+  test("Select new → Reset resets to Gate 1", async ({ page }) => {
     const gamePage = await completeE2EProgram(page);
 
     await gamePage.clickSelectNewProgram();

--- a/e2e/wrong-answer.spec.ts
+++ b/e2e/wrong-answer.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { GamePage } from "./pages/gamePage";
+import { SelectProgramPage } from "./pages/selectProgramPage";
+
+test.describe("@full wrong answer flow", () => {
+  test.beforeEach(async ({ page }) => {
+    const selectPage = new SelectProgramPage(page);
+    await selectPage.goto();
+    await selectPage.waitForLoad();
+    const gamePage = await selectPage.selectAndStart("E2E Test Program");
+    await gamePage.waitForLoad();
+  });
+
+  test("shows denial message and shake on wrong answer, then recovers", async ({
+    page,
+  }) => {
+    const gamePage = new GamePage(page);
+
+    // Submit wrong answer
+    const denialMsg = await gamePage.submitAnswerAndWaitForDenial("wrong");
+    expect(denialMsg).toContain("ACCESS DENIED");
+
+    // Should be shaking immediately after denial
+    // (shake auto-clears after 400ms, denial appears ~same time)
+    expect(await gamePage.isShaking()).toBe(true);
+
+    // Wait for shake to clear
+    await page.waitForTimeout(500);
+
+    // Submit correct answer — should proceed to Gate 2
+    await gamePage.submitAnswer("blue");
+    const result = await gamePage.waitForVerificationComplete();
+    expect(result).toContain("Correct!");
+
+    await gamePage.waitForActiveGateLabel("Gate 2");
+    const label = await gamePage.getActiveGateLabel();
+    expect(label).toBe("Gate 2");
+  });
+});


### PR DESCRIPTION
Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for incorrect answers, denial messages, and visual feedback.
  * Added coverage for completing a program and advancing to the next gate.
  * Added reset-flow scenarios for replaying, selecting a new program, keeping progress, cancelling, and confirming a reset.
  * Expanded gameplay test support for clues, completion actions, and reset confirmation dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->