### PR TITLE
✅ test(e2e): AI clue flow — seed gate with guidance, E2E test, data-testid selector

### DIFF
--- a/e2e/clue.spec.ts
+++ b/e2e/clue.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+import { GamePage } from "./pages/gamePage";
+import { SelectProgramPage } from "./pages/selectProgramPage";
+
+test.describe("@full clue flow", () => {
+  test.beforeEach(async ({ page }) => {
+    const selectPage = new SelectProgramPage(page);
+    await selectPage.goto();
+    await selectPage.waitForLoad();
+    const gamePage = await selectPage.selectAndStart("E2E Test Program");
+    await gamePage.waitForLoad();
+  });
+
+  test("requests and displays AI clue after reaching guidance threshold", async ({
+    page,
+  }) => {
+    const gamePage = new GamePage(page);
+
+    // Clue button hidden before any attempts (guidance_threshold = 2)
+    await expect(gamePage.getClueButtonLocator()).not.toBeVisible();
+
+    // Wrong answer #1: 1 attempt < threshold, button stays hidden
+    const denial1 = await gamePage.submitAnswerAndWaitForDenial("nope");
+    expect(denial1).toContain("ACCESS DENIED");
+    await expect(gamePage.getClueButtonLocator()).not.toBeVisible();
+
+    // Wrong answer #2: 2 attempts >= threshold, button appears
+    const denial2 = await gamePage.submitAnswerAndWaitForDenial("wrong");
+    expect(denial2).toContain("ACCESS DENIED");
+    await expect(gamePage.getClueButtonLocator()).toBeVisible();
+
+    // Request clue and verify AI-generated text appears
+    await gamePage.getClueButtonLocator().click();
+    const clueText = await gamePage.waitForClueText();
+    expect(clueText?.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/pages/gamePage.ts
+++ b/e2e/pages/gamePage.ts
@@ -238,10 +238,11 @@ export class GamePage {
 
   /**
    * Wait for clue text to appear in the clues list.
-   * Returns the first clue line text.
+   * Uses data-testid for resilience against CSS module class name changes.
+   * Returns the first clue line text (without the "- " prefix).
    */
   async waitForClueText(): Promise<string | null> {
-    const clueLine = this.page.locator("p.clueLine").first();
+    const clueLine = this.page.locator('[data-testid="clue-text"]').first();
     try {
       await clueLine.waitFor({ state: "visible", timeout: 15000 });
       return (await clueLine.textContent())?.trim() ?? null;

--- a/e2e/pages/gamePage.ts
+++ b/e2e/pages/gamePage.ts
@@ -242,7 +242,7 @@ export class GamePage {
    * Returns the first clue line text (without the "- " prefix).
    */
   async waitForClueText(): Promise<string | null> {
-    const clueLine = this.page.locator('[data-testid="clue-text"]').first();
+    const clueLine = this.page.locator("[data-testid='clue-text']").first();
     try {
       await clueLine.waitFor({ state: "visible", timeout: 15000 });
       return (await clueLine.textContent())?.trim() ?? null;

--- a/scripts/seed-e2e.sql
+++ b/scripts/seed-e2e.sql
@@ -1,6 +1,6 @@
 -- E2E Test Program — safe for concurrent runs
 -- programs: INSERT OR IGNORE so multiple PRs don't clash
--- gates: INSERT OR REPLACE so seed changes take effect on re-run
+-- gates: ON CONFLICT DO UPDATE so seed changes apply without FK cascade
 
 INSERT OR IGNORE INTO programs (id, name, created_at)
 VALUES (
@@ -9,8 +9,19 @@ VALUES (
   CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)
 );
 
-INSERT OR REPLACE INTO gates (id, program_id, sequence_order, label, question, correct_answer, success_message, acceptance_threshold, guidance_enabled, guidance_threshold, created_at)
+INSERT INTO gates (id, program_id, sequence_order, label, question, correct_answer, success_message, acceptance_threshold, guidance_enabled, guidance_threshold, created_at)
 VALUES
   ('e2e00001-0000-0000-0000-000000000001', 'e2e00000-0000-0000-0000-000000000001', 1, 'Gate 1', 'What color is the sky?', 'blue', 'Correct! The sky is blue during a clear day.', 0.875, 1, 2, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)),
   ('e2e00002-0000-0000-0000-000000000002', 'e2e00000-0000-0000-0000-000000000001', 2, 'Gate 2', 'What is 2 + 2?', '4', 'Correct! Basic arithmetic still holds.', 0.875, 0, 3, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)),
-  ('e2e00003-0000-0000-0000-000000000003', 'e2e00000-0000-0000-0000-000000000001', 3, 'Gate 3', 'What is the opposite of hot?', 'cold', 'Correct! Hot and cold are thermal opposites.', 0.875, 0, 3, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER));
+  ('e2e00003-0000-0000-0000-000000000003', 'e2e00000-0000-0000-0000-000000000001', 3, 'Gate 3', 'What is the opposite of hot?', 'cold', 'Correct! Hot and cold are thermal opposites.', 0.875, 0, 3, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))
+ON CONFLICT(id) DO UPDATE SET
+  program_id = excluded.program_id,
+  sequence_order = excluded.sequence_order,
+  label = excluded.label,
+  question = excluded.question,
+  correct_answer = excluded.correct_answer,
+  success_message = excluded.success_message,
+  acceptance_threshold = excluded.acceptance_threshold,
+  guidance_enabled = excluded.guidance_enabled,
+  guidance_threshold = excluded.guidance_threshold;
+-- NOTE: created_at intentionally omitted — preserve original timestamp

--- a/scripts/seed-e2e.sql
+++ b/scripts/seed-e2e.sql
@@ -1,5 +1,6 @@
--- E2E Test Program — purely additive, safe for concurrent runs
--- Uses INSERT OR IGNORE so multiple PRs/seeds don't clash.
+-- E2E Test Program — safe for concurrent runs
+-- programs: INSERT OR IGNORE so multiple PRs don't clash
+-- gates: INSERT OR REPLACE so seed changes take effect on re-run
 
 INSERT OR IGNORE INTO programs (id, name, created_at)
 VALUES (
@@ -8,8 +9,8 @@ VALUES (
   CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)
 );
 
-INSERT OR IGNORE INTO gates (id, program_id, sequence_order, label, question, correct_answer, success_message, acceptance_threshold, guidance_enabled, guidance_threshold, created_at)
+INSERT OR REPLACE INTO gates (id, program_id, sequence_order, label, question, correct_answer, success_message, acceptance_threshold, guidance_enabled, guidance_threshold, created_at)
 VALUES
-  ('e2e00001-0000-0000-0000-000000000001', 'e2e00000-0000-0000-0000-000000000001', 1, 'Gate 1', 'What color is the sky?', 'blue', 'Correct! The sky is blue during a clear day.', 0.875, 0, 3, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)),
+  ('e2e00001-0000-0000-0000-000000000001', 'e2e00000-0000-0000-0000-000000000001', 1, 'Gate 1', 'What color is the sky?', 'blue', 'Correct! The sky is blue during a clear day.', 0.875, 1, 2, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)),
   ('e2e00002-0000-0000-0000-000000000002', 'e2e00000-0000-0000-0000-000000000001', 2, 'Gate 2', 'What is 2 + 2?', '4', 'Correct! Basic arithmetic still holds.', 0.875, 0, 3, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)),
   ('e2e00003-0000-0000-0000-000000000003', 'e2e00000-0000-0000-0000-000000000001', 3, 'Gate 3', 'What is the opposite of hot?', 'cold', 'Correct! Hot and cold are thermal opposites.', 0.875, 0, 3, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER));

--- a/src/react-app/components/ActiveGate.module.css
+++ b/src/react-app/components/ActiveGate.module.css
@@ -58,13 +58,14 @@
   margin: 0 0 0.25rem;
 }
 
+.cluesBulletList {
+  margin: 0;
+  list-style-type: "- ";
+}
+
 .clueLine {
   margin: 0.25rem 0;
   color: var(--light-grey);
-}
-
-.clueLine::before {
-  content: "- ";
 }
 
 .promptCaret {

--- a/src/react-app/components/ActiveGate.module.css
+++ b/src/react-app/components/ActiveGate.module.css
@@ -63,6 +63,10 @@
   color: var(--light-grey);
 }
 
+.clueLine::before {
+  content: "- ";
+}
+
 .promptCaret {
   color: var(--green);
   margin-right: 0.5rem;

--- a/src/react-app/components/ActiveGate.spec.tsx
+++ b/src/react-app/components/ActiveGate.spec.tsx
@@ -193,8 +193,8 @@ describe("Clue Functionality", () => {
   it("renders clues in a list when clues array is not empty", () => {
     renderActiveGate({ clues: ["First Clue", "Second Clue"] });
     expect(screen.getByText("Clues:")).toBeInTheDocument();
-    expect(screen.getByText(/- First Clue/)).toBeInTheDocument();
-    expect(screen.getByText(/- Second Clue/)).toBeInTheDocument();
+    expect(screen.getByText("First Clue")).toBeInTheDocument();
+    expect(screen.getByText("Second Clue")).toBeInTheDocument();
   });
 
   it("renders 'Get Final Clue' button when clues length is MAX_CLUES_PER_GATE - 1", () => {

--- a/src/react-app/components/ActiveGate.tsx
+++ b/src/react-app/components/ActiveGate.tsx
@@ -119,15 +119,17 @@ export default function ActiveGate({
           {clues.length > 0 && (
             <div className={styles.cluesList} aria-live="polite">
               <p className={styles.cluesHeading}>Clues:</p>
-              {clues.map((clue) => (
-                <p
-                  key={clue}
-                  className={styles.clueLine}
-                  data-testid="clue-text"
-                >
-                  {clue}
-                </p>
-              ))}
+              <ul className={styles.cluesBulletList}>
+                {clues.map((clue) => (
+                  <li
+                    key={clue}
+                    className={styles.clueLine}
+                    data-testid="clue-text"
+                  >
+                    {clue}
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
         </form>

--- a/src/react-app/components/ActiveGate.tsx
+++ b/src/react-app/components/ActiveGate.tsx
@@ -119,10 +119,13 @@ export default function ActiveGate({
           {clues.length > 0 && (
             <div className={styles.cluesList} aria-live="polite">
               <p className={styles.cluesHeading}>Clues:</p>
-              {clues.map((clue, index) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: clues are read-only and order is stable
-                <p key={index} className={styles.clueLine}>
-                  - {clue}
+              {clues.map((clue) => (
+                <p
+                  key={clue}
+                  className={styles.clueLine}
+                  data-testid="clue-text"
+                >
+                  {clue}
                 </p>
               ))}
             </div>


### PR DESCRIPTION
## Changes

- **seed:** Gate 1 in E2E Test Program gets `guidance_enabled=1, guidance_threshold=2`; gates seed changed from `INSERT OR IGNORE` → `INSERT OR REPLACE` so updates take effect on re-seed
- **test:** `e2e/clue.spec.ts` — one `@full` test: 2 wrong answers → clue button appears → request real AI clue → verify non-empty text
- **component:** Added `data-testid="clue-text"` to `<p>` in clues list for resilient E2E selectors; switched `key={index}` → `key={clue}` (removes suppressed Biome lint)
- **page object:** `waitForClueText()` uses `[data-testid="clue-text"]` — CSS-module-safe

## Verification

- `bun run check:code` — clean
- `mise test:e2e` — 18/18 passed (chromium + firefox)

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced clue presentation using bullet-list formatting for clearer readability.
  - Added UI hooks so clue text can be detected consistently by automated checks.

- **Bug Fixes**
  - Improved clue text detection to match the latest on-screen structure.
  - Updated E2E seeding behavior so gate configuration changes apply correctly on re-runs (including guidance settings).

- **Tests**
  - Added a new end-to-end test covering the full AI clue flow: access denied attempts, clue reveal after threshold, and non-empty generated clue display.
  - Updated component tests to reflect the revised clue formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->