### PR TITLE
:white_check_mark: test: Integration tests - mutations & queries

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+
       - name: Delete preview worker
         uses: cloudflare/wrangler-action@v3
         with:

--- a/src/react-app/api/mutations/useRequestClueMutation.spec.ts
+++ b/src/react-app/api/mutations/useRequestClueMutation.spec.ts
@@ -128,6 +128,23 @@ describe("useRequestClueMutation", () => {
     ).rejects.toThrow("Network error");
   });
 
+  it("rejects on HTTP failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRequestClueMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ gateId: "gate-1", currentGuess: "5" }),
+    ).rejects.toThrow("GraphQL request failed with HTTP 500.");
+  });
+
   it("does not invalidate query cache (no onSuccess handler)", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/src/react-app/api/mutations/useRequestClueMutation.spec.ts
+++ b/src/react-app/api/mutations/useRequestClueMutation.spec.ts
@@ -1,0 +1,156 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryWrapper } from "../../test-utils/queryTestUtils";
+import { useRequestClueMutation } from "./useRequestClueMutation";
+
+const mockFetch = vi.fn();
+const mockProgramId = "test-program-id";
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch;
+});
+
+describe("useRequestClueMutation", () => {
+  it("requests clue and returns response on success", async () => {
+    const response = {
+      clueText: "Think about the number 4",
+      isClueLimitReached: false,
+      cluesRemaining: 2,
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { requestClue: response } }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRequestClueMutation(mockProgramId), {
+      wrapper,
+    });
+
+    const data = await result.current.mutateAsync({
+      gateId: "gate-1",
+      currentGuess: "5",
+    });
+
+    expect(data).toEqual(response);
+  });
+
+  it("sends correct mutation query and variables", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          requestClue: {
+            clueText: "Hint",
+            isClueLimitReached: false,
+            cluesRemaining: 2,
+          },
+        },
+      }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRequestClueMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync({
+      gateId: "gate-1",
+      currentGuess: "5",
+    });
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string);
+
+    expect(body.query).toContain("RequestClue");
+    expect(body.variables).toEqual({
+      programId: mockProgramId,
+      gateId: "gate-1",
+      currentGuess: "5",
+    });
+  });
+
+  it("returns null clueText when clue cannot be generated", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          requestClue: {
+            clueText: null,
+            isClueLimitReached: true,
+            cluesRemaining: 0,
+          },
+        },
+      }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRequestClueMutation(mockProgramId), {
+      wrapper,
+    });
+
+    const data = await result.current.mutateAsync({
+      gateId: "gate-1",
+      currentGuess: "wrong",
+    });
+
+    expect(data.clueText).toBeNull();
+    expect(data.isClueLimitReached).toBe(true);
+    expect(data.cluesRemaining).toBe(0);
+  });
+
+  it("rejects on GraphQL error response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ errors: [{ message: "Clue limit reached" }] }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRequestClueMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ gateId: "gate-1", currentGuess: "5" }),
+    ).rejects.toThrow("Clue limit reached");
+  });
+
+  it("rejects on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Network error"));
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRequestClueMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ gateId: "gate-1", currentGuess: "5" }),
+    ).rejects.toThrow("Network error");
+  });
+
+  it("does not invalidate query cache (no onSuccess handler)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          requestClue: {
+            clueText: "Hint",
+            isClueLimitReached: false,
+            cluesRemaining: 2,
+          },
+        },
+      }),
+    } as Response);
+
+    const { queryClient, wrapper } = createQueryWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRequestClueMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync({ gateId: "gate-1", currentGuess: "5" });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/react-app/api/mutations/useSubmitGuessMutation.spec.ts
+++ b/src/react-app/api/mutations/useSubmitGuessMutation.spec.ts
@@ -1,0 +1,139 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryWrapper } from "../../test-utils/queryTestUtils";
+import { useSubmitGuessMutation } from "./useSubmitGuessMutation";
+
+const mockFetch = vi.fn();
+const mockProgramId = "test-program-id";
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch;
+});
+
+describe("useSubmitGuessMutation", () => {
+  it("submits guess and returns response on success", async () => {
+    const response = {
+      success: true,
+      message: "Access Granted.",
+      canRequestClue: false,
+      nextGate: { id: "gate-2", label: "Gate 2", question: "Next?" },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { submitGuess: response } }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSubmitGuessMutation(mockProgramId), {
+      wrapper,
+    });
+
+    const data = await result.current.mutateAsync({
+      gateId: "gate-1",
+      guess: "my answer",
+    });
+
+    expect(data).toEqual(response);
+  });
+
+  it("sends correct mutation query and variables", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          submitGuess: { success: true, canRequestClue: false, nextGate: null },
+        },
+      }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSubmitGuessMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync({ gateId: "gate-1", guess: "my answer" });
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string);
+
+    expect(body.query).toContain("SubmitGuess");
+    expect(body.variables).toEqual({
+      programId: mockProgramId,
+      gateId: "gate-1",
+      guess: "my answer",
+    });
+  });
+
+  it("invalidates progression cache on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          submitGuess: { success: true, canRequestClue: false, nextGate: null },
+        },
+      }),
+    } as Response);
+
+    const { queryClient, wrapper } = createQueryWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useSubmitGuessMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync({ gateId: "gate-1", guess: "my answer" });
+
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["programs", "progression", mockProgramId],
+    });
+  });
+
+  it("rejects on GraphQL error response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        errors: [{ message: "Invalid guess" }],
+      }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSubmitGuessMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ gateId: "gate-1", guess: "wrong" }),
+    ).rejects.toThrow("Invalid guess");
+  });
+
+  it("rejects on HTTP failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSubmitGuessMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ gateId: "gate-1", guess: "my answer" }),
+    ).rejects.toThrow("GraphQL request failed with HTTP 500.");
+  });
+
+  it("rejects on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Network error"));
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSubmitGuessMutation(mockProgramId), {
+      wrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ gateId: "gate-1", guess: "my answer" }),
+    ).rejects.toThrow("Network error");
+  });
+});

--- a/src/react-app/api/queries/useInProgressProgramQuery.spec.ts
+++ b/src/react-app/api/queries/useInProgressProgramQuery.spec.ts
@@ -1,0 +1,108 @@
+import { useQuery } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryWrapper } from "../../test-utils/queryTestUtils";
+import { inProgressProgramQueryOptions } from "./useInProgressProgramQuery";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch;
+});
+
+describe("inProgressProgramQueryOptions", () => {
+  it("returns program id when session has in-progress program", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { getInProgressProgram: "prog-1" } }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => useQuery(inProgressProgramQueryOptions),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe("prog-1");
+  });
+
+  it("returns null when no in-progress program exists", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { getInProgressProgram: null } }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => useQuery(inProgressProgramQueryOptions),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("includes correct queryKey", () => {
+    expect(inProgressProgramQueryOptions.queryKey).toEqual([
+      "programs",
+      "inProgress",
+    ]);
+  });
+
+  it("sets staleTime to 0 for always-fresh data", () => {
+    expect(inProgressProgramQueryOptions.staleTime).toBe(0);
+  });
+
+  it("sends GetInProgressProgram query", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { getInProgressProgram: null } }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    renderHook(() => useQuery(inProgressProgramQueryOptions), { wrapper });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string);
+
+    expect(body.query).toContain("GetInProgressProgram");
+    expect(body.variables).toBeUndefined();
+  });
+
+  it("rejects on query error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => useQuery(inProgressProgramQueryOptions),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe(
+      "GraphQL request failed with HTTP 500.",
+    );
+  });
+
+  it("rejects on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Network error"));
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => useQuery(inProgressProgramQueryOptions),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("Network error");
+  });
+});

--- a/src/react-app/api/queries/useProgramProgressionQuery.spec.ts
+++ b/src/react-app/api/queries/useProgramProgressionQuery.spec.ts
@@ -91,6 +91,19 @@ describe("programProgressionQueryOptions", () => {
     );
   });
 
+  it("rejects on network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Network error"));
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => useQuery(programProgressionQueryOptions(mockProgramId)),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("Network error");
+  });
+
   it("handles null currentGate (completed program)", async () => {
     const progression = {
       currentGate: null,

--- a/src/react-app/api/queries/useProgramProgressionQuery.spec.ts
+++ b/src/react-app/api/queries/useProgramProgressionQuery.spec.ts
@@ -1,0 +1,124 @@
+import { useQuery } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryWrapper } from "../../test-utils/queryTestUtils";
+import { programProgressionQueryOptions } from "./useProgramProgressionQuery";
+
+const mockFetch = vi.fn();
+const mockProgramId = "test-program-id";
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch;
+});
+
+describe("programProgressionQueryOptions", () => {
+  it("fetches and returns program progression on success", async () => {
+    const progression = {
+      currentGate: { id: "gate-1", label: "Gate 1", question: "What is 2+2?" },
+      completedGates: [],
+      status: "in_progress",
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { getProgramProgression: progression } }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => useQuery(programProgressionQueryOptions(mockProgramId)),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(progression);
+  });
+
+  it("includes correct queryKey", () => {
+    const options = programProgressionQueryOptions(mockProgramId);
+    expect(options.queryKey).toEqual([
+      "programs",
+      "progression",
+      mockProgramId,
+    ]);
+  });
+
+  it("forwards programId in the query variables", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          getProgramProgression: {
+            currentGate: null,
+            completedGates: [],
+            status: "in_progress",
+          },
+        },
+      }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    renderHook(() => useQuery(programProgressionQueryOptions(mockProgramId)), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string);
+
+    expect(body.query).toContain("GetProgramProgression");
+    expect(body.variables).toEqual({ programId: mockProgramId });
+  });
+
+  it("rejects on query error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => useQuery(programProgressionQueryOptions(mockProgramId)),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe(
+      "GraphQL request failed with HTTP 500.",
+    );
+  });
+
+  it("handles null currentGate (completed program)", async () => {
+    const progression = {
+      currentGate: null,
+      completedGates: [
+        {
+          id: "gate-1",
+          label: "Gate 1",
+          question: "What is 2+2?",
+          correctAnswer: "4",
+          successMessage: "Correct!",
+        },
+      ],
+      status: "completed",
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { getProgramProgression: progression } }),
+    } as Response);
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => useQuery(programProgressionQueryOptions(mockProgramId)),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.currentGate).toBeNull();
+    expect(result.current.data?.completedGates).toHaveLength(1);
+    expect(result.current.data?.status).toBe("completed");
+  });
+});


### PR DESCRIPTION
- **✅ test(use-request-clue-mutation): add tests for request clue mutation**
- **✅ test(use-submit-guess-mutation): add tests for submit guess mutation**
- **✅ test(in-progress-program-query): add tests for in-progress program query**
- **✅ test(program-progression-query): add tests for program progression query**

Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for clue requests, guess submissions, in-progress programs, and program progression.
  * Verified successful responses, GraphQL and network errors, HTTP failures, null values, request payloads, cache behavior, and query configuration.
* **Chores**
  * Improved preview cleanup environment setup before removing preview resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->