### PR TITLE
:wrench: chore: Frontend integration testing cleanup

### DIFF
--- a/src/react-app/components/ProgramPlay.integration.spec.tsx
+++ b/src/react-app/components/ProgramPlay.integration.spec.tsx
@@ -1,3 +1,8 @@
+import {
+  mockActiveGate,
+  mockCompletedGate,
+  mockProgression,
+} from "@test-utils/msw/fixtures";
 import { createQueryWrapper } from "@test-utils/queryTestUtils";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -15,9 +20,10 @@ import {
 import type { ProgramProgression } from "../api/queries/useProgramProgressionQuery";
 import ProgramPlay from "./ProgramPlay";
 
-vi.mock("@tanstack/react-router", () => ({
-  useNavigate: vi.fn(() => vi.fn()),
-}));
+vi.mock(import("@tanstack/react-router"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) };
+});
 
 vi.mock("@routes/programs/$programId", () => ({
   Route: {
@@ -27,35 +33,6 @@ vi.mock("@routes/programs/$programId", () => ({
 }));
 
 let progressionData: ProgramProgression = mockProgression();
-
-function mockActiveGate(overrides: Record<string, unknown> = {}) {
-  return {
-    id: "active-gate-1",
-    label: "Gate 1",
-    question: "What is 2+2?",
-    ...overrides,
-  };
-}
-
-function mockCompletedGate(overrides: Record<string, unknown> = {}) {
-  return {
-    id: "completed-gate-1",
-    label: "Gate 1",
-    question: "What is 2+2?",
-    correctAnswer: "4",
-    successMessage: "Correct!",
-    ...overrides,
-  };
-}
-
-function mockProgression(overrides: Record<string, unknown> = {}) {
-  return {
-    currentGate: mockActiveGate(),
-    completedGates: [],
-    status: "in_progress",
-    ...overrides,
-  } as ProgramProgression;
-}
 
 const server = setupServer(
   graphql.query("GetProgramProgression", () =>

--- a/src/react-app/routes/-crossRouteFlow.integration.spec.tsx
+++ b/src/react-app/routes/-crossRouteFlow.integration.spec.tsx
@@ -1,3 +1,4 @@
+import { mockCompletedGate, mockProgression } from "@test-utils";
 import {
   createTestRouter,
   renderWithRouter,
@@ -9,11 +10,14 @@ import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { ProgramProgression } from "../api/queries/useProgramProgressionQuery";
 
-let progressionData: ProgramProgression = {
-  currentGate: { id: "gate-1", label: "Gate 1", question: "What is 2+2?" },
-  completedGates: [],
-  status: "in_progress",
-};
+let progressionData: ProgramProgression = mockProgression();
+
+const initialProgression: ProgramProgression = mockProgression();
+const completedProgression: ProgramProgression = mockProgression({
+  currentGate: null,
+  completedGates: [mockCompletedGate()],
+  status: "completed",
+});
 
 const server = setupServer(
   graphql.query("GetProgramProgression", () =>
@@ -21,19 +25,7 @@ const server = setupServer(
   ),
   graphql.mutation("SubmitGuess", ({ variables }) => {
     if (variables.guess === "4") {
-      progressionData = {
-        currentGate: null,
-        completedGates: [
-          {
-            id: "gate-1",
-            label: "Gate 1",
-            question: "What is 2+2?",
-            correctAnswer: "4",
-            successMessage: "Access Granted.",
-          },
-        ],
-        status: "completed",
-      };
+      progressionData = completedProgression;
       return HttpResponse.json({
         data: {
           submitGuess: {
@@ -57,11 +49,7 @@ const server = setupServer(
     });
   }),
   graphql.mutation("ResetSession", () => {
-    progressionData = {
-      currentGate: { id: "gate-1", label: "Gate 1", question: "What is 2+2?" },
-      completedGates: [],
-      status: "in_progress",
-    };
+    progressionData = initialProgression;
     return HttpResponse.json({ data: { resetSession: true } });
   }),
   graphql.query("GetPrograms", () =>
@@ -94,11 +82,7 @@ describe("Cross-Route Flow", () => {
   beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
   afterEach(() => {
     server.resetHandlers();
-    progressionData = {
-      currentGate: { id: "gate-1", label: "Gate 1", question: "What is 2+2?" },
-      completedGates: [],
-      status: "in_progress",
-    };
+    progressionData = mockProgression();
   });
   afterAll(() => server.close());
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,8 @@ export default defineConfig({
       ),
     },
     include: ["src/**/*.spec.{ts,tsx}"],
+    // Frontend integration specs (*.integration.spec.tsx) run here (happy-dom).
+    // Backend integration specs (*.integration.spec.ts) excluded; run via test:integration.
     exclude: [...configDefaults.exclude, "src/**/*.integration.spec.ts"],
     clearMocks: true,
     restoreMocks: true,

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -72,6 +72,7 @@ export default defineConfig({
     },
   },
   test: {
+    // Backend integration specs only. Frontend (*.tsx) excluded — needs happy-dom, not Workerd pool.
     include: ["src/**/*.integration.spec.ts"],
     // Mirror unit test config — automatically reset mocks between tests
     clearMocks: true,


### PR DESCRIPTION
- **✅ test(program-play): use shared fixtures and dynamic router mock**
- **✅ test(cross-route-flow): use mock utilities for progression data**
- **📝 docs(vite-config): add comments for integration test setup**

Closes #135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved frontend integration test reliability by using shared progression and gate fixtures.
  - Updated test scenarios for correct guesses, incorrect guesses, completed sessions, and session resets.
  - Preserved router behavior while allowing navigation to be mocked consistently.
  - Clarified how frontend and backend integration tests are separated across test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->