### PR TITLE
:white_check_mark: test: error branch coverage

### DIFF
--- a/src/react-app/components/ProgramPlay.spec.tsx
+++ b/src/react-app/components/ProgramPlay.spec.tsx
@@ -127,7 +127,35 @@ describe("ProgramPlay Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useProgramPlay).mockReturnValue(mockUseProgramPlay);
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
+
+  async function renderCompletedProgram() {
+    const completedProgression = {
+      currentGate: null,
+      completedGates: [
+        {
+          id: "gate-1",
+          label: "Gate 1",
+          question: "What is 2+2?",
+          correctAnswer: "4",
+          successMessage: "Correct!",
+        },
+      ],
+      status: "completed",
+    };
+
+    const { queryClient, wrapper } = createQueryWrapper();
+
+    queryClient.setQueryData(["programs"], mockPrograms);
+    queryClient.setQueryData(
+      ["programs", "progression", "test-program-id"],
+      completedProgression,
+    );
+
+    render(<ProgramPlay />, { wrapper });
+    await screen.findByText("The End");
+  }
 
   it("renders loading state when data is loading", () => {
     const { queryClient, wrapper } = createQueryWrapper();
@@ -202,31 +230,7 @@ describe("ProgramPlay Component", () => {
   });
 
   it("renders end state when program is completed", async () => {
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     expect(screen.getByText("Select new program")).toBeInTheDocument();
     expect(screen.getByText("Play program again")).toBeEnabled();
   });
@@ -287,31 +291,7 @@ describe("ProgramPlay Component", () => {
   });
 
   it("calls resetSessionMutation when 'Play program again' is clicked", async () => {
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     const playAgainButton = screen.getByText("Play program again");
     await userEvent.click(playAgainButton);
 
@@ -321,31 +301,7 @@ describe("ProgramPlay Component", () => {
   });
 
   it("opens confirm modal and resets session on confirm", async () => {
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     await userEvent.click(screen.getByText("Select new program"));
 
     expect(
@@ -362,31 +318,7 @@ describe("ProgramPlay Component", () => {
   });
 
   it("opens confirm modal and navigates without resetting on cancel", async () => {
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     await userEvent.click(screen.getByText("Select new program"));
 
     expect(
@@ -402,32 +334,7 @@ describe("ProgramPlay Component", () => {
 
   it("shows error when confirm reset fails", async () => {
     mockMutateAsync.mockResolvedValue(false);
-
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     await userEvent.click(screen.getByText("Select new program"));
     await userEvent.click(screen.getByText("Reset Progress"));
 
@@ -438,34 +345,8 @@ describe("ProgramPlay Component", () => {
   });
 
   it("shows error when confirm reset throws", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => {});
     mockMutateAsync.mockRejectedValue(new Error("Network error"));
-
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     await userEvent.click(screen.getByText("Select new program"));
     await userEvent.click(screen.getByText("Reset Progress"));
 
@@ -476,31 +357,7 @@ describe("ProgramPlay Component", () => {
   });
 
   it("closes confirm modal when cancel button is clicked", async () => {
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     await userEvent.click(screen.getByText("Select new program"));
 
     expect(
@@ -520,32 +377,7 @@ describe("ProgramPlay Component", () => {
 
   it("shows error when play again reset fails", async () => {
     mockMutateAsync.mockResolvedValue(false);
-
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     await userEvent.click(screen.getByText("Play program again"));
 
     expect(
@@ -554,34 +386,8 @@ describe("ProgramPlay Component", () => {
   });
 
   it("shows error when play again reset throws", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => {});
     mockMutateAsync.mockRejectedValue(new Error("Network error"));
-
-    const completedProgression = {
-      currentGate: null,
-      completedGates: [
-        {
-          id: "gate-1",
-          label: "Gate 1",
-          question: "What is 2+2?",
-          correctAnswer: "4",
-          successMessage: "Correct!",
-        },
-      ],
-      status: "completed",
-    };
-
-    const { queryClient, wrapper } = createQueryWrapper();
-
-    queryClient.setQueryData(["programs"], mockPrograms);
-    queryClient.setQueryData(
-      ["programs", "progression", "test-program-id"],
-      completedProgression,
-    );
-
-    render(<ProgramPlay />, { wrapper });
-
-    await screen.findByText("The End");
+    await renderCompletedProgram();
     await userEvent.click(screen.getByText("Play program again"));
 
     expect(

--- a/src/react-app/components/ProgramPlay.spec.tsx
+++ b/src/react-app/components/ProgramPlay.spec.tsx
@@ -41,8 +41,9 @@ vi.mock("@components/CompletedGate", () => ({
   default: vi.fn(() => null),
 }));
 
+const mockMutateAsync = vi.fn().mockResolvedValue(true);
 const mockResetSessionMutation = {
-  mutateAsync: vi.fn().mockResolvedValue(true),
+  mutateAsync: mockMutateAsync,
   isPending: false,
 } as unknown as UseMutationResult<
   boolean,
@@ -400,7 +401,7 @@ describe("ProgramPlay Component", () => {
   });
 
   it("shows error when confirm reset fails", async () => {
-    mockResetSessionMutation.mutateAsync.mockResolvedValue(false);
+    mockMutateAsync.mockResolvedValue(false);
 
     const completedProgression = {
       currentGate: null,
@@ -438,9 +439,7 @@ describe("ProgramPlay Component", () => {
 
   it("shows error when confirm reset throws", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    mockResetSessionMutation.mutateAsync.mockRejectedValue(
-      new Error("Network error"),
-    );
+    mockMutateAsync.mockRejectedValue(new Error("Network error"));
 
     const completedProgression = {
       currentGate: null,
@@ -520,7 +519,7 @@ describe("ProgramPlay Component", () => {
   });
 
   it("shows error when play again reset fails", async () => {
-    mockResetSessionMutation.mutateAsync.mockResolvedValue(false);
+    mockMutateAsync.mockResolvedValue(false);
 
     const completedProgression = {
       currentGate: null,
@@ -556,9 +555,7 @@ describe("ProgramPlay Component", () => {
 
   it("shows error when play again reset throws", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    mockResetSessionMutation.mutateAsync.mockRejectedValue(
-      new Error("Network error"),
-    );
+    mockMutateAsync.mockRejectedValue(new Error("Network error"));
 
     const completedProgression = {
       currentGate: null,

--- a/src/react-app/components/ProgramPlay.spec.tsx
+++ b/src/react-app/components/ProgramPlay.spec.tsx
@@ -398,4 +398,197 @@ describe("ProgramPlay Component", () => {
 
     expect(mockResetSessionMutation.mutateAsync).not.toHaveBeenCalled();
   });
+
+  it("shows error when confirm reset fails", async () => {
+    mockResetSessionMutation.mutateAsync.mockResolvedValue(false);
+
+    const completedProgression = {
+      currentGate: null,
+      completedGates: [
+        {
+          id: "gate-1",
+          label: "Gate 1",
+          question: "What is 2+2?",
+          correctAnswer: "4",
+          successMessage: "Correct!",
+        },
+      ],
+      status: "completed",
+    };
+
+    const { queryClient, wrapper } = createQueryWrapper();
+
+    queryClient.setQueryData(["programs"], mockPrograms);
+    queryClient.setQueryData(
+      ["programs", "progression", "test-program-id"],
+      completedProgression,
+    );
+
+    render(<ProgramPlay />, { wrapper });
+
+    await screen.findByText("The End");
+    await userEvent.click(screen.getByText("Select new program"));
+    await userEvent.click(screen.getByText("Reset Progress"));
+
+    const errors = screen.getAllByText(
+      "Failed to reset progress. Please try again.",
+    );
+    expect(errors).toHaveLength(2);
+  });
+
+  it("shows error when confirm reset throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockResetSessionMutation.mutateAsync.mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    const completedProgression = {
+      currentGate: null,
+      completedGates: [
+        {
+          id: "gate-1",
+          label: "Gate 1",
+          question: "What is 2+2?",
+          correctAnswer: "4",
+          successMessage: "Correct!",
+        },
+      ],
+      status: "completed",
+    };
+
+    const { queryClient, wrapper } = createQueryWrapper();
+
+    queryClient.setQueryData(["programs"], mockPrograms);
+    queryClient.setQueryData(
+      ["programs", "progression", "test-program-id"],
+      completedProgression,
+    );
+
+    render(<ProgramPlay />, { wrapper });
+
+    await screen.findByText("The End");
+    await userEvent.click(screen.getByText("Select new program"));
+    await userEvent.click(screen.getByText("Reset Progress"));
+
+    const errors = screen.getAllByText(
+      "Failed to reset progress. Please try again.",
+    );
+    expect(errors).toHaveLength(2);
+  });
+
+  it("closes confirm modal when cancel button is clicked", async () => {
+    const completedProgression = {
+      currentGate: null,
+      completedGates: [
+        {
+          id: "gate-1",
+          label: "Gate 1",
+          question: "What is 2+2?",
+          correctAnswer: "4",
+          successMessage: "Correct!",
+        },
+      ],
+      status: "completed",
+    };
+
+    const { queryClient, wrapper } = createQueryWrapper();
+
+    queryClient.setQueryData(["programs"], mockPrograms);
+    queryClient.setQueryData(
+      ["programs", "progression", "test-program-id"],
+      completedProgression,
+    );
+
+    render(<ProgramPlay />, { wrapper });
+
+    await screen.findByText("The End");
+    await userEvent.click(screen.getByText("Select new program"));
+
+    expect(
+      screen.getByText(
+        `Reset your progress on "Test Program" before selecting a new one?`,
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("[x]"));
+
+    expect(
+      screen.queryByText(
+        `Reset your progress on "Test Program" before selecting a new one?`,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows error when play again reset fails", async () => {
+    mockResetSessionMutation.mutateAsync.mockResolvedValue(false);
+
+    const completedProgression = {
+      currentGate: null,
+      completedGates: [
+        {
+          id: "gate-1",
+          label: "Gate 1",
+          question: "What is 2+2?",
+          correctAnswer: "4",
+          successMessage: "Correct!",
+        },
+      ],
+      status: "completed",
+    };
+
+    const { queryClient, wrapper } = createQueryWrapper();
+
+    queryClient.setQueryData(["programs"], mockPrograms);
+    queryClient.setQueryData(
+      ["programs", "progression", "test-program-id"],
+      completedProgression,
+    );
+
+    render(<ProgramPlay />, { wrapper });
+
+    await screen.findByText("The End");
+    await userEvent.click(screen.getByText("Play program again"));
+
+    expect(
+      screen.getByText("Failed to reset progress. Please try again."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error when play again reset throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockResetSessionMutation.mutateAsync.mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    const completedProgression = {
+      currentGate: null,
+      completedGates: [
+        {
+          id: "gate-1",
+          label: "Gate 1",
+          question: "What is 2+2?",
+          correctAnswer: "4",
+          successMessage: "Correct!",
+        },
+      ],
+      status: "completed",
+    };
+
+    const { queryClient, wrapper } = createQueryWrapper();
+
+    queryClient.setQueryData(["programs"], mockPrograms);
+    queryClient.setQueryData(
+      ["programs", "progression", "test-program-id"],
+      completedProgression,
+    );
+
+    render(<ProgramPlay />, { wrapper });
+
+    await screen.findByText("The End");
+    await userEvent.click(screen.getByText("Play program again"));
+
+    expect(
+      screen.getByText("Failed to reset progress. Please try again."),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/react-app/hooks/useProgramPlay.spec.ts
+++ b/src/react-app/hooks/useProgramPlay.spec.ts
@@ -6,11 +6,14 @@ import useProgramPlay from "./useProgramPlay";
 // Mock the mutations
 const mockMutateAsync = vi.fn();
 const mockMutate = vi.fn();
+let mockSubmitIsPending = false;
 
 vi.mock("@api/mutations/useSubmitGuessMutation", () => ({
   useSubmitGuessMutation: vi.fn(() => ({
     mutateAsync: mockMutateAsync,
-    isPending: false,
+    get isPending() {
+      return mockSubmitIsPending;
+    },
   })),
 }));
 
@@ -38,6 +41,7 @@ describe("useProgramPlay", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSubmitIsPending = false;
   });
 
   it("starts with an empty guess", () => {
@@ -118,6 +122,25 @@ describe("useProgramPlay", () => {
     expect(result.current.message).toBe("Correct!");
   });
 
+  it("sets message to null when success message is null", async () => {
+    const { result } = renderHook(
+      () => useProgramPlay({ programId, currentGateId }),
+      { wrapper },
+    );
+    mockMutateAsync.mockResolvedValue({
+      success: true,
+      message: null,
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.SubmitEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message).toBeNull();
+  });
+
   it("clears the guess", async () => {
     const { result } = renderHook(
       () => useProgramPlay({ programId, currentGateId }),
@@ -170,6 +193,39 @@ describe("useProgramPlay", () => {
     });
 
     expect(result.current.message).toBe("Wrong!");
+  });
+
+  it("falls back to 'Access Denied.' when error message is null", async () => {
+    const { result } = renderHook(
+      () => useProgramPlay({ programId, currentGateId }),
+      { wrapper },
+    );
+    mockMutateAsync.mockResolvedValue({
+      success: false,
+      message: null,
+      canRequestClue: false,
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.SubmitEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message).toBe("Access Denied.");
+  });
+
+  it("does nothing when handleRequestClue is called with no currentGateId", () => {
+    const { result } = renderHook(
+      () => useProgramPlay({ programId, currentGateId: null }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.handleRequestClue();
+    });
+
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
   it("sets isShaking to true", async () => {
@@ -257,6 +313,40 @@ describe("useProgramPlay", () => {
     });
 
     expect(result.current.canRequestClue).toBe(false);
+  });
+
+  it("returns early when mutation is pending", async () => {
+    mockSubmitIsPending = true;
+
+    const { result } = renderHook(
+      () => useProgramPlay({ programId, currentGateId }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.SubmitEvent<HTMLFormElement>);
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("sets error message when currentGateId is null", async () => {
+    const { result } = renderHook(
+      () => useProgramPlay({ programId, currentGateId: null }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.SubmitEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message).toBe("No active gate to submit guess to");
+    expect(result.current.guessSucceeded).toBe(false);
+    expect(mockMutateAsync).not.toHaveBeenCalled();
   });
 
   it("sets message to error text", async () => {

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -10,6 +10,7 @@ vi.mock("@worker-services/aiService", () => ({
 }));
 
 import { generateClue } from "@worker-services/aiService";
+import { createMockGraphQLContext } from "@worker-test-utils/mockEnv";
 import isGuessCloseEnough from "@worker-utils/isGuessCloseEnough";
 import type { AppGraphQLContext } from "./types";
 
@@ -51,14 +52,11 @@ function createMockDb(): MockDb {
   };
 }
 
-function createMockContext(mockDb: MockDb): AppGraphQLContext {
-  return {
-    get: vi.fn((key: string) => {
-      if (key === "db") return mockDb;
-      if (key === "sessionId") return "mock-session-456";
-      return undefined;
-    }),
-  } as unknown as AppGraphQLContext;
+function createMockContext(mockDb: MockDb) {
+  return createMockGraphQLContext({
+    db: mockDb,
+    sessionId: "mock-session-456",
+  });
 }
 
 const defaultGate = {
@@ -255,12 +253,7 @@ describe("Gameplay Mutations: submitGuess", () => {
   });
 
   it("throws when session ID is missing for guess submission", async () => {
-    const noSessionContext = {
-      get: vi.fn((key: string) => {
-        if (key === "db") return mockDb;
-        return undefined;
-      }),
-    } as unknown as AppGraphQLContext;
+    const noSessionContext = createMockGraphQLContext({ db: mockDb });
 
     if (!submitGuess.resolve) throw new Error("Resolver not defined");
 
@@ -450,12 +443,7 @@ describe("Gameplay Mutations: requestClue", () => {
   });
 
   it("throws when session ID is missing", async () => {
-    const contextWithoutSession = {
-      get: vi.fn((key: string) => {
-        if (key === "db") return mockDb;
-        return undefined;
-      }),
-    } as unknown as AppGraphQLContext;
+    const contextWithoutSession = createMockGraphQLContext({ db: mockDb });
 
     if (!requestClue.resolve) throw new Error("Resolver not defined");
 
@@ -804,12 +792,7 @@ describe("Gameplay Mutations: resetSession", () => {
   });
 
   it("throws when session ID is missing", async () => {
-    const noSessionContext = {
-      get: vi.fn((key: string) => {
-        if (key === "db") return mockDb;
-        return undefined;
-      }),
-    } as unknown as AppGraphQLContext;
+    const noSessionContext = createMockGraphQLContext({ db: mockDb });
 
     if (!resetSession.resolve) throw new Error("Resolver not defined");
 

--- a/src/worker/graphql/gameplay/mutations.spec.ts
+++ b/src/worker/graphql/gameplay/mutations.spec.ts
@@ -254,6 +254,156 @@ describe("Gameplay Mutations: submitGuess", () => {
     expect(result.canRequestClue).toBe(true);
   });
 
+  it("throws when session ID is missing for guess submission", async () => {
+    const noSessionContext = {
+      get: vi.fn((key: string) => {
+        if (key === "db") return mockDb;
+        return undefined;
+      }),
+    } as unknown as AppGraphQLContext;
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      submitGuess.resolve(
+        null,
+        { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+        noSessionContext,
+      ),
+    ).rejects.toThrow("Unauthorized: Missing Session ID");
+  });
+
+  it("throws when guess is empty", async () => {
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      submitGuess.resolve(
+        null,
+        { programId: "prog-1", gateId: "gate-1", guess: "" },
+        mockContext,
+      ),
+    ).rejects.toThrow("Invalid guess length.");
+  });
+
+  it("throws when guess exceeds max length", async () => {
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      submitGuess.resolve(
+        null,
+        { programId: "prog-1", gateId: "gate-1", guess: "a".repeat(501) },
+        mockContext,
+      ),
+    ).rejects.toThrow("Invalid guess length.");
+  });
+
+  it("throws when program is already completed", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      status: "completed",
+    });
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      submitGuess.resolve(
+        null,
+        { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+        mockContext,
+      ),
+    ).rejects.toThrow("Program already completed or not started.");
+  });
+
+  it("throws when guess submitted for wrong active gate", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      currentGateId: "other-gate",
+    });
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      submitGuess.resolve(
+        null,
+        { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+        mockContext,
+      ),
+    ).rejects.toThrow("Desync: Guess submitted for the wrong active gate.");
+  });
+
+  it("throws when gate does not exist", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      currentGateId: "nonexistent",
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(null);
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      submitGuess.resolve(
+        null,
+        { programId: "prog-1", gateId: "nonexistent", guess: "banana" },
+        mockContext,
+      ),
+    ).rejects.toThrow("Gate with ID nonexistent not found.");
+  });
+
+  it("throws when attempt count update fails after incorrect guess", async () => {
+    mockDb.query.sessionProgress.findFirst
+      .mockResolvedValueOnce(defaultProgress)
+      .mockResolvedValueOnce(null);
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    vi.mocked(isGuessCloseEnough).mockReturnValue(false);
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      submitGuess.resolve(
+        null,
+        { programId: "prog-1", gateId: "gate-1", guess: "banana" },
+        mockContext,
+      ),
+    ).rejects.toThrow("Failed to update attempt count.");
+  });
+
+  it("transitions to next gate when correct guess and next gate exists", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      currentGateId: "gate-2",
+      attemptCount: 4,
+    });
+    mockDb.query.gates.findFirst
+      .mockResolvedValueOnce({
+        id: "gate-2",
+        correctAnswer: "banana",
+        sequenceOrder: 2,
+        successMessage: "Nice!",
+        guidanceEnabled: true,
+        guidanceThreshold: 2,
+      })
+      .mockResolvedValueOnce({ id: "gate-3" });
+    vi.mocked(isGuessCloseEnough).mockReturnValue(true);
+
+    if (!submitGuess.resolve) throw new Error("Resolver not defined");
+
+    const result = await submitGuess.resolve(
+      null,
+      { programId: "prog-2", gateId: "gate-2", guess: "banana" },
+      mockContext,
+    );
+
+    expect(result.success).toBe(true);
+    const setCall = mockDb.update.mock.results[0]?.value.set;
+    expect(setCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentGateId: "gate-3",
+        attemptCount: 0,
+        status: "in_progress",
+      }),
+    );
+  });
+
   it("returns true, resets attemptCount, and sets canRequestClue false on correct guess", async () => {
     mockDb.query.sessionProgress.findFirst.mockResolvedValue({
       ...defaultProgress,
@@ -567,6 +717,79 @@ describe("Gameplay Mutations: requestClue", () => {
       cluesRemaining: 0,
     });
   });
+
+  it("throws when program is completed for clue request", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      status: "completed",
+    });
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      requestClue.resolve(
+        null,
+        {
+          programId: "prog-1",
+          gateId: "gate-1",
+          currentGuess: "banana",
+        },
+        mockContext,
+      ),
+    ).rejects.toThrow("Program already completed or not started.");
+  });
+
+  it("throws when gate does not exist for clue request", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      currentGateId: "nonexistent",
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(null);
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    await expect(
+      requestClue.resolve(
+        null,
+        {
+          programId: "prog-1",
+          gateId: "nonexistent",
+          currentGuess: "banana",
+        },
+        mockContext,
+      ),
+    ).rejects.toThrow("Gate with ID nonexistent not found.");
+  });
+
+  it("handles duplicate clue insert gracefully", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockDb.query.sessionProgress.findFirst.mockResolvedValue({
+      ...defaultProgress,
+      attemptCount: 3,
+    });
+    mockDb.query.gates.findFirst.mockResolvedValue(defaultGate);
+    mockDb.query.gateClues.findMany.mockResolvedValue([]);
+    vi.mocked(generateClue).mockResolvedValue("A juicy hint.");
+
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockRejectedValue(new Error("UNIQUE constraint")),
+    });
+
+    if (!requestClue.resolve) throw new Error("Resolver not defined");
+
+    const result = await requestClue.resolve(
+      null,
+      {
+        programId: "prog-1",
+        gateId: "gate-1",
+        currentGuess: "banana",
+      },
+      mockContext,
+    );
+
+    expect(result.clueText).toBeNull();
+    expect(result.isClueLimitReached).toBe(false);
+  });
 });
 
 describe("Gameplay Mutations: resetSession", () => {
@@ -656,5 +879,26 @@ describe("Gameplay Mutations: resetSession", () => {
     );
 
     expect(result).toBe(false);
+  });
+
+  it("resets to null currentGate when no first gate is found", async () => {
+    mockDb.query.sessionProgress.findFirst.mockResolvedValueOnce({
+      id: "progress-1",
+    });
+    mockDb.query.gates.findFirst.mockResolvedValueOnce(null);
+
+    if (!resetSession.resolve) throw new Error("Resolver not defined");
+
+    const result = await resetSession.resolve(
+      null,
+      { programId: "prog-empty" },
+      mockContext,
+    );
+
+    expect(result).toBe(true);
+    const setCall = mockDb.update.mock.results[0]?.value.set;
+    expect(setCall).toHaveBeenCalledWith(
+      expect.objectContaining({ currentGateId: null }),
+    );
   });
 });

--- a/src/worker/graphql/gameplay/queries.spec.ts
+++ b/src/worker/graphql/gameplay/queries.spec.ts
@@ -51,9 +51,9 @@ function contextWith(db: MockDb, sessionId?: string): AppGraphQLContext {
 
 const SID = "mock-session-id";
 
-function resolveField<T>(
-  field: { resolve?: (...args: any[]) => T },
-  ...args: any[]
+function resolveField<T, TArgs extends unknown[]>(
+  field: { resolve?: (...args: TArgs) => T },
+  ...args: TArgs
 ): T {
   if (!field.resolve) throw new Error("Resolver not defined");
   return field.resolve(...args);

--- a/src/worker/test-utils/mockEnv.ts
+++ b/src/worker/test-utils/mockEnv.ts
@@ -2,6 +2,7 @@ import type { Ai, D1Database } from "@cloudflare/workers-types";
 import type { Context } from "hono";
 import { type Mock, vi } from "vitest";
 import type { Env } from "..";
+import type { AppGraphQLContext } from "../graphql/gameplay/types";
 
 export function createMockEnv(
   overrides: Partial<Env["Bindings"]> = {},
@@ -22,4 +23,18 @@ export function createMockHonoContext(
   const c = { env: mockEnv } as unknown as Context;
 
   return { c, aiRunMock };
+}
+
+export function createMockGraphQLContext(options?: {
+  db?: unknown;
+  sessionId?: string;
+}): AppGraphQLContext {
+  const { db, sessionId } = options || {};
+  return {
+    get: vi.fn((key: string) => {
+      if (key === "db") return db;
+      if (key === "sessionId") return sessionId;
+      return undefined;
+    }),
+  } as unknown as AppGraphQLContext;
 }


### PR DESCRIPTION
- **✅ test(program-play): add error and cancel modal tests for reset flow**
- **✅ test(use-program-play): add edge case tests for submit handling**
- **✅ test(gameplay-mutations): add extensive error handling tests for gameplay mutations**

Closes #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for session reset failures, cancellations, and error handling.
  * Added tests for blocked or invalid guess submissions, missing gates, pending requests, and null messages.
  * Added coverage for completed programs, unavailable clues, duplicate clue requests, and session resets without a first gate.
  * Improved resolver test type safety without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->