### PR TITLE
🔧 chore(ci): improve playwright caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deploy.outcome == 'success'
         run: echo "version=$(bunx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
-      - name: Cache Playwright browsers
+      - name: Cache Playwright browsers (restore-only)
         uses: actions/cache@v6
         id: playwright-cache
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deploy.outcome == 'success'
@@ -73,9 +73,14 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
 
+      - name: Install Playwright system dependencies
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deploy.outcome == 'success'
+        run: bunx playwright install-deps chromium firefox
+
       - name: Install Playwright browsers
+        id: playwright-install
         if: steps.playwright-cache.outputs.cache-hit != 'true' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deploy.outcome == 'success'
-        run: bunx playwright install --with-deps chromium firefox
+        run: bunx playwright install chromium firefox
 
       - name: Run E2E Tests
         id: e2e
@@ -104,7 +109,7 @@ jobs:
 
       - name: Update Deployment (Failure)
         uses: chrnorm/deployment-status@v2
-        if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deployment.conclusion != 'skipped' && (steps.deploy.outcome != 'success' || steps.e2e.outcome == 'failure')
+        if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deployment.conclusion != 'skipped' && (steps.deploy.outcome != 'success' || steps.e2e.outcome == 'failure' || steps.playwright-version.outcome == 'failure' || steps.playwright-cache.outcome == 'failure' || steps.playwright-install.outcome == 'failure')
         with:
           token: ${{ github.token }}
           state: 'error'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,23 @@ jobs:
               || format('deploy --env preview --name quiz-app-preview-pr-{0}', github.event.pull_request.number)
             }}
 
+      - name: Get Playwright version
+        id: playwright-version
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deploy.outcome == 'success'
+        run: echo "version=$(bunx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        id: playwright-cache
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deploy.outcome == 'success'
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deploy.outcome == 'success'
+        run: bunx playwright install --with-deps chromium firefox
+
       - name: Run E2E Tests
         id: e2e
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.deploy.outcome == 'success'

--- a/mise.toml
+++ b/mise.toml
@@ -57,11 +57,8 @@ description = "Run Playwright E2E tests"
 
 [tasks."test:e2e:ci"]
 depends = ["seed:e2e:preview"]
-run = [
-    "bunx playwright install chromium firefox",
-    "bunx playwright test",
-]
-description = "Seed preview D1, install browsers, run E2E against BASE_URL (for CI)"
+run = "bunx playwright test"
+description = "Run E2E against BASE_URL (browsers installed separately in CI)"
 
 [tasks."cf-typegen"]
 run = "bun run cf-typegen"


### PR DESCRIPTION
Closes #166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request end-to-end test setup by caching Playwright browsers and installing them only when needed.
  * Streamlined CI test execution by separating browser installation from test runs.
  * Updated task descriptions to clarify the CI and local test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->